### PR TITLE
Fix feedback specificity, script safety, framework routing, hooks step

### DIFF
--- a/plugins/pas/.claude-plugin/plugin.json
+++ b/plugins/pas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pas",
   "description": "Process-Agent-Skill framework for building agentic workflows. Create automated pipelines with composable processes, agents, and skills that improve through feedback.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Zoran Spirkovski"
   },

--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -43,11 +43,17 @@ if [ ! -d "$FEEDBACK_DIR" ]; then
   exit 0
 fi
 
-# Primary check: feedback .md files in workspace
-FEEDBACK_COUNT=$(find "$FEEDBACK_DIR" -maxdepth 1 -name "*.md" 2>/dev/null | wc -l)
-
-if [ "$FEEDBACK_COUNT" -gt 0 ]; then
-  exit 0  # Self-eval found
+# Primary check: agent-specific feedback file
+if [ "$AGENT_ID" != "unknown" ] && [ -n "$AGENT_ID" ]; then
+  # Look for files matching this agent's name pattern
+  if find "$FEEDBACK_DIR" -maxdepth 1 \( -name "${AGENT_ID}.md" -o -name "${AGENT_ID}-*.md" \) 2>/dev/null | grep -q .; then
+    exit 0  # Agent-specific self-eval found
+  fi
+else
+  # Unknown agent — fall back to any .md file
+  if find "$FEEDBACK_DIR" -maxdepth 1 -name "*.md" 2>/dev/null | grep -q .; then
+    exit 0  # Self-eval found (agent unknown, accepting any)
+  fi
 fi
 
 # Secondary check (P1): scan transcript for inline signal patterns

--- a/plugins/pas/hooks/route-feedback.sh
+++ b/plugins/pas/hooks/route-feedback.sh
@@ -58,6 +58,10 @@ resolve_target_path() {
       fi
       echo "${found:-}"
       ;;
+    framework)
+      # Sentinel value — caller handles framework routing via route_framework_signal()
+      echo "__framework__"
+      ;;
     *)
       echo ""
       ;;
@@ -78,6 +82,49 @@ route_signal() {
   echo "$signal_block" > "$dest_file"
 }
 
+route_framework_signal() {
+  local signal_block="$1"
+  local signal_id="$2"
+  local log_dir="$CWD/feedback"
+  mkdir -p "$log_dir"
+
+  # Guard: only route signals marked for GitHub issue creation
+  if ! echo "$signal_block" | grep -q 'Route: github-issue'; then
+    echo "[$(date -Iseconds)] INFO: Framework signal ${signal_id} not marked 'Route: github-issue', skipping" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+    return 0
+  fi
+
+  # Guard: check gh CLI is available and authenticated
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] WARNING: gh CLI not found, cannot route ${signal_id} to GitHub" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+    return 0
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] WARNING: gh not authenticated, cannot route ${signal_id} to GitHub" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+    return 0
+  fi
+
+  # Extract a one-line summary from the signal block
+  local summary
+  summary=$(echo "$signal_block" | grep -E '^(Degraded:|Preference:|Rejected Change:|Behavior:)' | head -1 | sed 's/^[^:]*:[[:space:]]*//')
+  if [ -z "$summary" ]; then
+    # Fallback: use the second line (first line after the signal ID header)
+    summary=$(echo "$signal_block" | sed -n '2p' | sed 's/^[[:space:]]*//')
+  fi
+  # Truncate summary to 80 chars
+  summary=$(echo "$summary" | cut -c1-80)
+
+  # File as GitHub issue
+  if gh issue create --repo ZoranSpirkovski/PAS \
+    --title "[Feedback] ${signal_id}: ${summary}" \
+    --body "$signal_block" >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] OK: Filed ${signal_id} as GitHub issue" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+  else
+    echo "[$(date -Iseconds)] ERROR: Failed to file ${signal_id} as GitHub issue" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+  fi
+}
+
 parse_and_route_signals() {
   local text="$1"
   local source_name="$2"
@@ -92,7 +139,9 @@ parse_and_route_signals() {
       if [ -n "$current_signal" ] && [ -n "$current_target" ]; then
         local target_path
         target_path=$(resolve_target_path "$current_target")
-        if [ -n "$target_path" ]; then
+        if [ "$target_path" = "__framework__" ]; then
+          route_framework_signal "$current_signal" "$current_id"
+        elif [ -n "$target_path" ]; then
           route_signal "$current_signal" "$current_id" "$source_name" "$target_path"
         else
           mkdir -p "$CWD/feedback"
@@ -118,7 +167,9 @@ $line"
   if [ -n "$current_signal" ] && [ -n "$current_target" ]; then
     local target_path
     target_path=$(resolve_target_path "$current_target")
-    if [ -n "$target_path" ]; then
+    if [ "$target_path" = "__framework__" ]; then
+      route_framework_signal "$current_signal" "$current_id"
+    elif [ -n "$target_path" ]; then
       route_signal "$current_signal" "$current_id" "$source_name" "$target_path"
     else
       mkdir -p "$CWD/feedback"

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/SKILL.md
@@ -62,10 +62,13 @@ bash ${CLAUDE_SKILL_DIR}/scripts/pas-create-agent \
   --behavior "{behavioral rule 1}" \
   --behavior "{behavioral rule 2}" \
   --deliverable "{what the agent produces}" \
-  --role {orchestrator|specialist}
+  --role {orchestrator|specialist} \
+  --base-dir {directory}
 ```
 
 Repeatable flags: `--behavior` (required, at least one), `--deliverable` (required, at least one).
+
+Optional: `--base-dir` sets the root directory for output (default: current directory).
 
 When `--role orchestrator`, the script automatically:
 - Merges required orchestrator tools (Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, Agent, SendMessage, TeamCreate)

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/scripts/pas-create-agent
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/scripts/pas-create-agent
@@ -11,6 +11,7 @@ MODEL=""
 TOOLS=""
 IDENTITY=""
 ROLE="specialist"
+BASE_DIR=""
 FORCE=false
 declare -a BEHAVIORS=()
 declare -a DELIVERABLES=()
@@ -33,6 +34,7 @@ Required:
   --deliverable TEXT    What the agent produces (repeatable)
 
 Optional:
+  --base-dir DIR        Base directory for output (default: current directory)
   --role TYPE           orchestrator or specialist (default: specialist)
   --force               Overwrite existing directory
 USAGE
@@ -50,6 +52,7 @@ while [[ $# -gt 0 ]]; do
     --identity) IDENTITY="$2"; shift 2 ;;
     --behavior) BEHAVIORS+=("$2"); shift 2 ;;
     --deliverable) DELIVERABLES+=("$2"); shift 2 ;;
+    --base-dir) BASE_DIR="$2"; shift 2 ;;
     --role) ROLE="$2"; shift 2 ;;
     --force) FORCE=true; shift ;;
     --help|-h) usage ;;
@@ -120,7 +123,7 @@ if [[ "$ROLE" == "orchestrator" ]]; then
 fi
 
 # Build target path
-TARGET="processes/${PROCESS}/agents/${NAME}"
+TARGET="${BASE_DIR:+${BASE_DIR}/}processes/${PROCESS}/agents/${NAME}"
 
 # Check directory conflict
 if [[ -d "$TARGET" && "$FORCE" != true ]]; then

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/references/pas-feedback-hooks.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/references/pas-feedback-hooks.md
@@ -12,13 +12,13 @@ Set up PAS feedback hooks when ALL of these are true:
 
 ### check-self-eval.sh (SubagentStop)
 
-**Purpose:** Safety net that warns when an agent shuts down without writing self-evaluation.
+**Purpose:** Blocks an agent from shutting down unless it has written its own self-evaluation file.
 
 **Event:** SubagentStop
 **Handler:** command
 **Timeout:** 10 seconds
 
-**Enhanced script (with P1 improvements):**
+**Script (agent-specific check, blocking):**
 
 ```bash
 #!/usr/bin/env bash
@@ -66,11 +66,17 @@ if [ ! -d "$FEEDBACK_DIR" ]; then
   exit 0
 fi
 
-# Primary check: feedback .md files in workspace
-FEEDBACK_COUNT=$(find "$FEEDBACK_DIR" -maxdepth 1 -name "*.md" 2>/dev/null | wc -l)
-
-if [ "$FEEDBACK_COUNT" -gt 0 ]; then
-  exit 0  # Self-eval found
+# Primary check: agent-specific feedback file
+if [ "$AGENT_ID" != "unknown" ] && [ -n "$AGENT_ID" ]; then
+  # Look for files matching this agent's name pattern
+  if find "$FEEDBACK_DIR" -maxdepth 1 \( -name "${AGENT_ID}.md" -o -name "${AGENT_ID}-*.md" \) 2>/dev/null | grep -q .; then
+    exit 0  # Agent-specific self-eval found
+  fi
+else
+  # Unknown agent — fall back to any .md file
+  if find "$FEEDBACK_DIR" -maxdepth 1 -name "*.md" 2>/dev/null | grep -q .; then
+    exit 0  # Self-eval found (agent unknown, accepting any)
+  fi
 fi
 
 # Secondary check (P1): scan transcript for inline signal patterns
@@ -81,183 +87,40 @@ if [ -n "$AGENT_TRANSCRIPT" ] && [ -f "$AGENT_TRANSCRIPT" ]; then
   fi
 fi
 
-# No self-eval found — log warning with agent_id
-WARNINGS_DIR="$CWD/feedback"
-mkdir -p "$WARNINGS_DIR"
-echo "[$(date -Iseconds)] WARNING: Agent '$AGENT_ID' shutdown without writing self-eval to $FEEDBACK_DIR" >> "$WARNINGS_DIR/warnings.log"
+# No self-eval found — block subagent from stopping
+cat >&2 <<EOF
+SELF-EVALUATION MISSING
 
-exit 0
+Agent '${AGENT_ID}' is shutting down without writing self-evaluation.
+
+Before stopping, write your self-evaluation to:
+  ${FEEDBACK_DIR}/${AGENT_ID}.md
+
+Use library/self-evaluation/SKILL.md for the format.
+If nothing went wrong, write "No issues detected."
+EOF
+exit 2
 ```
 
 ### route-feedback.sh (Stop)
 
-**Purpose:** Routes feedback signals from workspace feedback inbox to artifact backlogs.
+**Purpose:** Routes feedback signals from workspace feedback inbox to artifact backlogs. Framework signals (`Target: framework:pas` with `Route: github-issue`) are filed as GitHub issues automatically.
 
 **Event:** Stop
 **Handler:** command
 **Timeout:** 30 seconds
 
-**Enhanced script (with P1 improvements and issue #3 fixes):**
+**Script (with plugins/ fallback, framework routing, .routed markers):**
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
+The canonical version lives at `plugins/pas/hooks/route-feedback.sh`. Key features:
 
-# Stop hook: routes feedback signals to artifact backlogs.
-# Enhanced: also extracts signals from last_assistant_message,
-# mkdir -p before all log writes, sort-by-mtime for workspace detection.
+- `resolve_target_path()` searches `$CWD/processes/`, then `$CWD/plugins/` as fallback for process/agent/skill targets
+- `framework)` case returns sentinel `__framework__` which triggers `route_framework_signal()`
+- `route_framework_signal()` files GitHub issues via `gh issue create` for signals marked `Route: github-issue`
+- Guards: checks `gh auth status` before attempting; logs to `$CWD/feedback/framework-routing.log`
+- Processed feedback files are marked with `.routed` companion file instead of deleted
 
-INPUT=$(cat)
-
-CWD=$(echo "$INPUT" | jq -r '.cwd')
-LAST_MESSAGE=$(echo "$INPUT" | jq -r '.last_assistant_message // empty')
-
-if [ -z "$CWD" ]; then
-  exit 0
-fi
-
-# --- Functions ---
-
-find_active_workspace() {
-  local workspace_dir="$CWD/workspace"
-  if [ ! -d "$workspace_dir" ]; then
-    return 1
-  fi
-
-  local active_status
-  active_status=$(find "$workspace_dir" -name "status.yaml" -print 2>/dev/null | while read -r f; do
-    echo "$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0) $f"
-  done | sort -rn | head -1 | awk '{print $2}')
-
-  if [ -z "$active_status" ]; then
-    return 1
-  fi
-
-  dirname "$active_status"
-}
-
-resolve_target_path() {
-  local target="$1"
-  local type value
-
-  type=$(echo "$target" | cut -d: -f1)
-  value=$(echo "$target" | cut -d: -f2-)
-
-  case "$type" in
-    process)
-      echo "$CWD/processes/$value/feedback/backlog"
-      ;;
-    agent)
-      local found
-      found=$(find "$CWD/processes" -path "*/agents/$value/feedback/backlog" -type d 2>/dev/null | head -1)
-      echo "${found:-}"
-      ;;
-    skill)
-      local found
-      found=$(find "$CWD/processes" -path "*/skills/$value/feedback/backlog" -type d 2>/dev/null | head -1)
-      if [ -z "$found" ]; then
-        found=$(find "$CWD/library" -path "*/$value/feedback/backlog" -type d 2>/dev/null | head -1)
-      fi
-      echo "${found:-}"
-      ;;
-    *)
-      echo ""
-      ;;
-  esac
-}
-
-route_signal() {
-  local signal_block="$1"
-  local signal_id="$2"
-  local source_basename="$3"
-  local target_path="$4"
-  local today
-
-  today=$(date +%Y-%m-%d)
-  local dest_file="$target_path/${today}-${source_basename}-${signal_id}.md"
-
-  mkdir -p "$target_path"
-  echo "$signal_block" > "$dest_file"
-}
-
-parse_and_route_signals() {
-  local text="$1"
-  local source_name="$2"
-
-  local current_signal=""
-  local current_id=""
-  local current_target=""
-
-  while IFS= read -r line || [ -n "$line" ]; do
-    if echo "$line" | grep -qE '^\[(PPU|OQI|GATE|STA)-[0-9]+\]'; then
-      # Route previous signal
-      if [ -n "$current_signal" ] && [ -n "$current_target" ]; then
-        local target_path
-        target_path=$(resolve_target_path "$current_target")
-        if [ -n "$target_path" ]; then
-          route_signal "$current_signal" "$current_id" "$source_name" "$target_path"
-        else
-          mkdir -p "$CWD/feedback"
-          echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$CWD/feedback/warnings.log" 2>/dev/null || true
-        fi
-      fi
-
-      current_id=$(echo "$line" | grep -oE '(PPU|OQI|GATE|STA)-[0-9]+')
-      current_signal="$line"
-      current_target=""
-    else
-      if [ -n "$current_id" ]; then
-        current_signal="$current_signal
-$line"
-      fi
-      if echo "$line" | grep -qE '^Target:'; then
-        current_target=$(echo "$line" | sed 's/^Target:[[:space:]]*//')
-      fi
-    fi
-  done <<< "$text"
-
-  # Route last signal
-  if [ -n "$current_signal" ] && [ -n "$current_target" ]; then
-    local target_path
-    target_path=$(resolve_target_path "$current_target")
-    if [ -n "$target_path" ]; then
-      route_signal "$current_signal" "$current_id" "$source_name" "$target_path"
-    else
-      mkdir -p "$CWD/feedback"
-      echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$CWD/feedback/warnings.log" 2>/dev/null || true
-    fi
-  fi
-}
-
-# --- Main ---
-
-# Find active workspace
-ACTIVE_WORKSPACE=$(find_active_workspace) || exit 0
-FEEDBACK_DIR="$ACTIVE_WORKSPACE/feedback"
-
-# Route from .md files (primary mechanism)
-if [ -d "$FEEDBACK_DIR" ]; then
-  FEEDBACK_FILES=$(find "$FEEDBACK_DIR" -maxdepth 1 -name "*.md" 2>/dev/null)
-
-  if [ -n "$FEEDBACK_FILES" ]; then
-    echo "$FEEDBACK_FILES" | while read -r feedback_file; do
-      [ -f "$feedback_file" ] || continue
-      source_basename=$(basename "$feedback_file" .md)
-      parse_and_route_signals "$(cat "$feedback_file")" "$source_basename"
-      rm "$feedback_file"
-    done
-  fi
-fi
-
-# Route from last_assistant_message (P1 — catches inline feedback)
-if [ -n "$LAST_MESSAGE" ]; then
-  if echo "$LAST_MESSAGE" | grep -qE '\[(PPU|OQI|GATE|STA)-[0-9]+\]'; then
-    parse_and_route_signals "$LAST_MESSAGE" "inline-final-message"
-  fi
-fi
-
-exit 0
-```
+Refer to the deployed script at `${CLAUDE_PLUGIN_ROOT}/hooks/route-feedback.sh` for the full implementation.
 
 ## Hook Registration
 

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
@@ -86,10 +86,13 @@ bash ${CLAUDE_SKILL_DIR}/scripts/pas-create-process \
   --phase "{name}:{agent}:{input}:{output}:{gate}" \
   --input "{name}:{description}" \
   --description "{brief description}" \
-  --sequential {true|false}
+  --sequential {true|false} \
+  --base-dir {directory}
 ```
 
 Repeatable flags: `--phase` (required, at least one), `--input` (required, at least one).
+
+Optional: `--base-dir` sets the root directory for output (default: current directory). Use for test isolation to avoid generating into the project's real `processes/` directory.
 
 This creates the process directory (process.md, mode files, references/, feedback/), thin launcher, and changelog.
 
@@ -101,7 +104,19 @@ For each agent determined in step 4, use `creating-agents/SKILL.md`:
 - Follow its workflow for each agent
 - The orchestrator agent is always created first
 
-### 8. Verify Against Source Material
+### 8. Determine Hooks
+
+Evaluate whether the process needs lifecycle hooks:
+
+- **Feedback hooks**: If `pas-config.yaml` has `feedback: enabled`, the PAS plugin's hooks handle self-eval and routing automatically. No per-process hooks needed for feedback.
+- **Domain-specific guards**: Does any phase need pre-conditions checked before tool use? (e.g., block destructive commands, validate inputs)
+- **Lifecycle automation**: Should anything happen automatically at session start, agent stop, or task completion?
+
+If hooks are needed, use `creating-hooks/SKILL.md` from the same skills directory as this skill.
+
+Most processes do not need custom hooks — the PAS plugin's global hooks cover feedback lifecycle. Only add hooks when the process has domain-specific automation needs.
+
+### 9. Verify Against Source Material
 
 If Step 2 (Prepare Reference Material) was used, cross-check every created skill against the reference doc:
 

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/scripts/pas-create-process
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/scripts/pas-create-process
@@ -9,6 +9,7 @@ GOAL=""
 ORCHESTRATION=""
 DESCRIPTION=""
 SEQUENTIAL="false"
+BASE_DIR=""
 FORCE=false
 declare -a PHASES=()
 declare -a INPUTS=()
@@ -27,6 +28,7 @@ Required:
   --input SPEC          Input spec as "name:description" (repeatable)
 
 Optional:
+  --base-dir DIR        Base directory for output (default: current directory)
   --description TEXT    Prose description for process.md body
   --sequential BOOL     Force linear execution (default: false)
   --force               Overwrite existing directory
@@ -42,6 +44,7 @@ while [[ $# -gt 0 ]]; do
     --orchestration) ORCHESTRATION="$2"; shift 2 ;;
     --phase) PHASES+=("$2"); shift 2 ;;
     --input) INPUTS+=("$2"); shift 2 ;;
+    --base-dir) BASE_DIR="$2"; shift 2 ;;
     --description) DESCRIPTION="$2"; shift 2 ;;
     --sequential) SEQUENTIAL="$2"; shift 2 ;;
     --force) FORCE=true; shift ;;
@@ -98,7 +101,7 @@ for input in "${INPUTS[@]}"; do
 done
 
 # Build target path
-TARGET="processes/${NAME}"
+TARGET="${BASE_DIR:+${BASE_DIR}/}processes/${NAME}"
 
 # Check directory conflict
 if [[ -d "$TARGET" && "$FORCE" != true ]]; then
@@ -261,7 +264,7 @@ echo "  Created ${TARGET}/feedback/backlog/.gitkeep"
 FILE_COUNT=$((FILE_COUNT + 1))
 
 # Generate thin launcher
-LAUNCHER_DIR=".claude/skills/${NAME}"
+LAUNCHER_DIR="${BASE_DIR:+${BASE_DIR}/}.claude/skills/${NAME}"
 mkdir -p "${LAUNCHER_DIR}"
 cat > "${LAUNCHER_DIR}/SKILL.md" <<EOF
 ---

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/SKILL.md
@@ -57,10 +57,13 @@ bash ${CLAUDE_SKILL_DIR}/scripts/pas-create-skill \
   --step "{Step 2 instruction}" \
   --output-format "{What the skill produces}" \
   --quality-check "{Self-check criterion}" \
-  --common-mistake "{Known pitfall}"
+  --common-mistake "{Known pitfall}" \
+  --base-dir {directory}
 ```
 
 Repeatable flags: `--step` (required, at least one), `--quality-check`, `--common-mistake`.
+
+Optional: `--base-dir` sets the root directory for output (default: current directory).
 
 **Key rules from the Agent Skills spec:**
 - Description = when to use, NOT what it does. Start with "Use when..."

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/scripts/pas-create-skill
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/scripts/pas-create-skill
@@ -12,6 +12,7 @@ OVERVIEW=""
 WHEN_TO_USE=""
 WHEN_NOT_TO_USE=""
 OUTPUT_FORMAT=""
+BASE_DIR=""
 FORCE=false
 declare -a STEPS=()
 declare -a QUALITY_CHECKS=()
@@ -30,6 +31,7 @@ Required:
   --step TEXT           Process step (repeatable, in order)
 
 Optional:
+  --base-dir DIR        Base directory for output (default: current directory)
   --when-to-use TEXT    Specific trigger conditions
   --when-not-to-use TEXT  When NOT to use
   --output-format TEXT  What the skill produces
@@ -54,6 +56,7 @@ while [[ $# -gt 0 ]]; do
     --output-format) OUTPUT_FORMAT="$2"; shift 2 ;;
     --quality-check) QUALITY_CHECKS+=("$2"); shift 2 ;;
     --common-mistake) COMMON_MISTAKES+=("$2"); shift 2 ;;
+    --base-dir) BASE_DIR="$2"; shift 2 ;;
     --force) FORCE=true; shift ;;
     --help|-h) usage ;;
     *) echo "Error: Unknown flag '$1'"; usage ;;
@@ -81,7 +84,7 @@ if [[ ! "$NAME" =~ ^[a-z][a-z0-9-]*$ ]]; then
 fi
 
 # Build target path
-TARGET="processes/${PROCESS}/agents/${AGENT}/skills/${NAME}"
+TARGET="${BASE_DIR:+${BASE_DIR}/}processes/${PROCESS}/agents/${AGENT}/skills/${NAME}"
 
 # Check directory conflict
 if [[ -d "$TARGET" && "$FORCE" != true ]]; then


### PR DESCRIPTION
## Summary

- **check-self-eval.sh agent-specificity bug**: Hook checked for ANY .md file in feedback dir instead of the stopping agent's file. First agent to write feedback let all others pass unchecked. Now checks `${AGENT_ID}.md` or `${AGENT_ID}-*.md` patterns, with fallback to any .md when agent is unknown.
- **Generation script safety (`--base-dir`)**: All 3 scripts (`pas-create-process`, `pas-create-agent`, `pas-create-skill`) now accept `--base-dir DIR` for safe test isolation. Prevents `rm -rf` cleanup at project root from destroying real processes (previously destroyed 53 files).
- **Framework feedback routing**: `route-feedback.sh` now handles `Target: framework:pas` signals via `gh issue create` instead of silently dropping them. Includes guards for gh auth status and `Route: github-issue` marker.
- **Hooks step restoration**: Step 8 "Determine Hooks" restored in creating-processes SKILL.md (lost during v1.2.0 simplification).
- **Version sync**: plugin.json updated to 1.3.0.
- **Reference doc**: pas-feedback-hooks.md slimmed to point at deployed scripts as canonical source (eliminates reference drift).

## Validation

- All 5 tasks passed QA validation including functional test (`--base-dir /tmp/pas-qa-test`)
- `bash -n` syntax check passed on all modified scripts
- CHANGELOG.md v1.3.0 entries that were aspirational are now accurate

## Issues

- Closes #6 (all 7 sub-problems now addressed)
- Validated and closed #11 (workspace recognition — SessionStart hook works)
- Validated and closed #12 (self-eval skipped — enforcement hooks work)
- Opened #13 (TeamCreate agents can't write to shared workspace — new finding)

## Test plan

- [ ] Verify `check-self-eval.sh` blocks agent without matching feedback file
- [ ] Verify `--base-dir /tmp/test` creates artifacts in temp dir, not project root
- [ ] Verify `route-feedback.sh` files `framework:pas` signals as GitHub issues when `Route: github-issue` is present
- [ ] Verify creating-processes SKILL.md has 9 steps with Step 8 "Determine Hooks"
- [ ] Verify all version fields show 1.3.0