### PR TITLE
Fix feedback file deletion, extract hook workspace utility, add claim verification

### DIFF
--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -22,19 +22,16 @@ if [ "$FEEDBACK_STATUS" != "enabled" ]; then
   exit 0
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/workspace.sh"
+
 # Find active workspace (sort-by-mtime approach)
 WORKSPACE_DIR="$CWD/workspace"
 if [ ! -d "$WORKSPACE_DIR" ]; then
   exit 0
 fi
 
-ACTIVE_STATUS=$(find "$WORKSPACE_DIR" -name "status.yaml" -print 2>/dev/null | while read -r f; do
-  echo "$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0) $f"
-done | sort -rn | head -1 | awk '{print $2}')
-
-if [ -z "$ACTIVE_STATUS" ]; then
-  exit 0
-fi
+ACTIVE_STATUS=$(find_active_workspace_status "$WORKSPACE_DIR") || exit 0
 
 ACTIVE_WORKSPACE=$(dirname "$ACTIVE_STATUS")
 FEEDBACK_DIR="$ACTIVE_WORKSPACE/feedback"

--- a/plugins/pas/hooks/lib/workspace.sh
+++ b/plugins/pas/hooks/lib/workspace.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Shared workspace detection utility for PAS hooks.
+
+find_active_workspace_status() {
+  local workspace_dir="$1"
+  if [ ! -d "$workspace_dir" ]; then
+    return 1
+  fi
+
+  local result
+  result=$(find "$workspace_dir" -name "status.yaml" -print 2>/dev/null | while read -r f; do
+    echo "$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0) $f"
+  done | sort -rn | head -1 | awk '{print $2}')
+
+  if [ -z "$result" ]; then
+    return 1
+  fi
+
+  echo "$result"
+}

--- a/plugins/pas/hooks/pas-session-start.sh
+++ b/plugins/pas/hooks/pas-session-start.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionStart hook: injects PAS lifecycle context and records session tracking.
+# stdout from this hook becomes context Claude sees in its conversation.
+# Also writes current_session to status.yaml so the Stop hook can verify
+# feedback was written by THIS session, not a previous one.
+
+INPUT=$(cat)
+
+CWD=$(echo "$INPUT" | jq -r '.cwd')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+# Guard: only run in PAS repos
+PAS_CONFIG="$CWD/pas-config.yaml"
+if [ ! -f "$PAS_CONFIG" ]; then
+  exit 0
+fi
+
+FEEDBACK_STATUS=$(grep -o 'feedback:[[:space:]]*\w*' "$PAS_CONFIG" | head -1 | awk '{print $NF}')
+
+# Derive short session ID (first 8 chars)
+SESSION_SHORT=""
+if [ -n "$SESSION_ID" ]; then
+  SESSION_SHORT=$(echo "$SESSION_ID" | cut -c1-8)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/workspace.sh"
+
+# Check for active workspace
+ACTIVE_STATUS=""
+WORKSPACE_DIR="$CWD/workspace"
+if [ -d "$WORKSPACE_DIR" ]; then
+  ACTIVE_STATUS=$(find_active_workspace_status "$WORKSPACE_DIR" 2>/dev/null) || true
+fi
+
+# Record session in status.yaml (if active workspace exists)
+if [ -n "$ACTIVE_STATUS" ] && [ -n "$SESSION_SHORT" ]; then
+  TIMESTAMP=$(date -Iseconds)
+
+  # Write current_session marker
+  if grep -q '^current_session:' "$ACTIVE_STATUS" 2>/dev/null; then
+    sed -i "s/^current_session:.*/current_session: ${SESSION_SHORT}/" "$ACTIVE_STATUS"
+  else
+    echo "current_session: ${SESSION_SHORT}" >> "$ACTIVE_STATUS"
+  fi
+
+  # Append to sessions list if not already recorded
+  if ! grep -q "id: ${SESSION_SHORT}" "$ACTIVE_STATUS" 2>/dev/null; then
+    if ! grep -q '^sessions:' "$ACTIVE_STATUS" 2>/dev/null; then
+      echo "" >> "$ACTIVE_STATUS"
+      echo "sessions:" >> "$ACTIVE_STATUS"
+    fi
+    cat >> "$ACTIVE_STATUS" <<EOF
+  - id: ${SESSION_SHORT}
+    started_at: ${TIMESTAMP}
+    completed_at: ~
+    feedback_collected: false
+EOF
+  fi
+fi
+
+# Build context message
+if [ -n "$SESSION_SHORT" ]; then
+  SESSION_CONTEXT="Session ID: ${SESSION_SHORT}"
+else
+  SESSION_CONTEXT="Session ID: unknown"
+fi
+
+cat <<EOF
+PAS Framework Active (feedback: ${FEEDBACK_STATUS})
+${SESSION_CONTEXT}
+
+When running a PAS process, you MUST follow this lifecycle:
+
+STARTUP (before any work):
+1. Create workspace: mkdir -p workspace/{process}/{slug}/{discovery,planning,execution/changes,validation,feedback}
+2. Write status.yaml with all phases as pending
+3. Create Claude Code tasks for each phase AND for shutdown steps:
+   - One task per phase from process.md
+   - Task: "[PAS] Self-evaluation" — write feedback/orchestrator-{session_id}.md
+   - Task: "[PAS] Route framework signals" — file framework:pas signals as GitHub issues
+   - Task: "[PAS] Finalize status" — set status.yaml to completed with completed_at timestamp
+
+SHUTDOWN (after all phases complete):
+1. Write self-evaluation to workspace/{process}/{slug}/feedback/orchestrator-${SESSION_SHORT:-SESSION_ID}.md
+2. Route any framework:pas signals as GitHub issues
+3. Update status.yaml: set status to completed with completed_at timestamp
+4. Mark all shutdown tasks as completed
+
+ENFORCEMENT: Hooks will block you from stopping or completing tasks if deliverables are missing.
+Feedback files MUST include your session ID (${SESSION_SHORT:-unknown}) in the filename.
+EOF
+
+# If there's an active workspace, show its status
+if [ -n "$ACTIVE_STATUS" ]; then
+  ACTIVE_WORKSPACE=$(dirname "$ACTIVE_STATUS")
+  TOP_STATUS=$(grep '^status:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
+  PROCESS_NAME=$(grep '^process:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
+  INSTANCE=$(grep '^instance:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
+
+  echo ""
+  echo "Active workspace: ${PROCESS_NAME}/${INSTANCE} (status: ${TOP_STATUS})"
+  echo "Path: ${ACTIVE_WORKSPACE}"
+
+  if [ "$TOP_STATUS" = "in_progress" ]; then
+    echo "This session may be a continuation. Read status.yaml to determine where to resume."
+  fi
+fi
+
+exit 0

--- a/plugins/pas/hooks/route-feedback.sh
+++ b/plugins/pas/hooks/route-feedback.sh
@@ -14,24 +14,15 @@ if [ -z "$CWD" ]; then
   exit 0
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/workspace.sh"
+
 # --- Functions ---
 
 find_active_workspace() {
-  local workspace_dir="$CWD/workspace"
-  if [ ! -d "$workspace_dir" ]; then
-    return 1
-  fi
-
-  local active_status
-  active_status=$(find "$workspace_dir" -name "status.yaml" -print 2>/dev/null | while read -r f; do
-    echo "$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0) $f"
-  done | sort -rn | head -1 | awk '{print $2}')
-
-  if [ -z "$active_status" ]; then
-    return 1
-  fi
-
-  dirname "$active_status"
+  local status_path
+  status_path=$(find_active_workspace_status "$CWD/workspace") || return 1
+  dirname "$status_path"
 }
 
 resolve_target_path() {
@@ -191,9 +182,11 @@ if [ -d "$FEEDBACK_DIR" ]; then
   if [ -n "$FEEDBACK_FILES" ]; then
     echo "$FEEDBACK_FILES" | while read -r feedback_file; do
       [ -f "$feedback_file" ] || continue
+      # Skip already-routed files
+      [ -f "${feedback_file}.routed" ] && continue
       source_basename=$(basename "$feedback_file" .md)
       parse_and_route_signals "$(cat "$feedback_file")" "$source_basename"
-      rm "$feedback_file"
+      touch "${feedback_file}.routed"
     done
   fi
 fi

--- a/plugins/pas/hooks/verify-completion-gate.sh
+++ b/plugins/pas/hooks/verify-completion-gate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop hook: blocks Claude from stopping when work is done but feedback is missing.
+# Only blocks when ALL phases are completed and no feedback file exists for the
+# current session. Uses session_id from status.yaml (written by SessionStart hook)
+# to check for session-specific feedback: feedback/orchestrator-{session_id}.md.
+# Uses stop_hook_active to prevent infinite blocking loops.
+
+INPUT=$(cat)
+
+CWD=$(echo "$INPUT" | jq -r '.cwd')
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+# Prevent infinite loops: if we already blocked once, let Claude stop
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+# Guard: only run in PAS repos with feedback enabled
+PAS_CONFIG="$CWD/pas-config.yaml"
+if [ ! -f "$PAS_CONFIG" ]; then
+  exit 0
+fi
+
+FEEDBACK_STATUS=$(grep -o 'feedback:[[:space:]]*\w*' "$PAS_CONFIG" | head -1 | awk '{print $NF}')
+if [ "$FEEDBACK_STATUS" != "enabled" ]; then
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/workspace.sh"
+
+# Find active workspace (most recently modified status.yaml)
+WORKSPACE_DIR="$CWD/workspace"
+if [ ! -d "$WORKSPACE_DIR" ]; then
+  exit 0
+fi
+
+ACTIVE_STATUS=$(find_active_workspace_status "$WORKSPACE_DIR") || exit 0
+
+ACTIVE_WORKSPACE=$(dirname "$ACTIVE_STATUS")
+FEEDBACK_DIR="$ACTIVE_WORKSPACE/feedback"
+
+# Check: are there any pending phases?
+PENDING_COUNT=$(grep -c '^\s*status: pending' "$ACTIVE_STATUS" 2>/dev/null) || PENDING_COUNT=0
+
+# If phases are still pending, work is in progress — don't block
+if [ "$PENDING_COUNT" -gt 0 ]; then
+  exit 0
+fi
+
+# Derive short session ID
+SESSION_SHORT=""
+if [ -n "$SESSION_ID" ]; then
+  SESSION_SHORT=$(echo "$SESSION_ID" | cut -c1-8)
+else
+  # Fallback: read current_session from status.yaml
+  SESSION_SHORT=$(grep '^current_session:' "$ACTIVE_STATUS" 2>/dev/null | awk '{print $2}')
+fi
+
+# All phases completed. Check for session-specific feedback.
+if [ -n "$SESSION_SHORT" ]; then
+  # Session-aware check: look for feedback/orchestrator-{session_id}.md
+  SESSION_FEEDBACK="$FEEDBACK_DIR/orchestrator-${SESSION_SHORT}.md"
+  if [ -f "$SESSION_FEEDBACK" ]; then
+    exit 0
+  fi
+  EXPECTED_FILE="orchestrator-${SESSION_SHORT}.md"
+else
+  # No session ID available — fall back to any orchestrator feedback file
+  if ls "$FEEDBACK_DIR"/orchestrator*.md 1>/dev/null 2>&1; then
+    exit 0
+  fi
+  EXPECTED_FILE="orchestrator-{session_id}.md"
+fi
+
+# BLOCK: All phases completed but no feedback for this session
+cat >&2 <<EOF
+COMPLETION GATE FAILED
+
+All phases are completed but you have not written your self-evaluation for this session.
+
+Before stopping, you MUST:
+1. Write self-evaluation to ${FEEDBACK_DIR}/${EXPECTED_FILE}
+   - Use library/self-evaluation/SKILL.md for the format
+   - If nothing went wrong, write "No issues detected."
+2. Route any framework:pas signals as GitHub issues
+3. Update status.yaml: set status to completed and completed_at timestamp
+
+You cannot stop until these steps are done.
+EOF
+exit 2

--- a/plugins/pas/hooks/verify-task-completion.sh
+++ b/plugins/pas/hooks/verify-task-completion.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# TaskCompleted hook: blocks PAS shutdown tasks from completing
+# until their deliverables exist on disk.
+#
+# Matched tasks (by subject pattern):
+#   "[PAS] Self-evaluation" → feedback/orchestrator.md must exist
+#   "[PAS] Finalize status" → status.yaml must have status: completed
+#   "[PAS] Route framework signals" → allowed (can't verify GitHub issues from bash)
+
+INPUT=$(cat)
+
+CWD=$(echo "$INPUT" | jq -r '.cwd')
+TASK_SUBJECT=$(echo "$INPUT" | jq -r '.task_subject // empty')
+
+# Guard: only run in PAS repos
+PAS_CONFIG="$CWD/pas-config.yaml"
+if [ ! -f "$PAS_CONFIG" ]; then
+  exit 0
+fi
+
+# Only act on PAS-prefixed tasks
+if ! echo "$TASK_SUBJECT" | grep -q '^\[PAS\]'; then
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/workspace.sh"
+
+# Find active workspace
+WORKSPACE_DIR="$CWD/workspace"
+if [ ! -d "$WORKSPACE_DIR" ]; then
+  exit 0
+fi
+
+ACTIVE_STATUS=$(find_active_workspace_status "$WORKSPACE_DIR") || exit 0
+
+ACTIVE_WORKSPACE=$(dirname "$ACTIVE_STATUS")
+FEEDBACK_DIR="$ACTIVE_WORKSPACE/feedback"
+
+# Check by task type
+case "$TASK_SUBJECT" in
+  *"Self-evaluation"*)
+    # Check for session-specific feedback file
+    CURRENT_SESSION=$(grep '^current_session:' "$ACTIVE_STATUS" 2>/dev/null | awk '{print $2}')
+    if [ -n "$CURRENT_SESSION" ]; then
+      ORCHESTRATOR_FEEDBACK="$FEEDBACK_DIR/orchestrator-${CURRENT_SESSION}.md"
+    else
+      # Fallback: accept any orchestrator feedback file
+      ORCHESTRATOR_FEEDBACK=$(ls "$FEEDBACK_DIR"/orchestrator*.md 2>/dev/null | head -1)
+    fi
+
+    if [ -z "$ORCHESTRATOR_FEEDBACK" ] || [ ! -f "$ORCHESTRATOR_FEEDBACK" ]; then
+      EXPECTED="orchestrator-${CURRENT_SESSION:-SESSION_ID}.md"
+      cat >&2 <<EOF
+Cannot complete "Self-evaluation" task: ${FEEDBACK_DIR}/${EXPECTED} does not exist.
+
+Write your self-evaluation to this file before marking the task complete.
+Use library/self-evaluation/SKILL.md for the format.
+EOF
+      exit 2
+    fi
+    ;;
+
+  *"Finalize status"*)
+    TOP_STATUS=$(grep '^status:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
+    COMPLETED_AT=$(grep '^completed_at:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
+
+    if [ "$TOP_STATUS" != "completed" ] || [ "$COMPLETED_AT" = "~" ] || [ -z "$COMPLETED_AT" ]; then
+      cat >&2 <<EOF
+Cannot complete "Finalize status" task: status.yaml is not finalized.
+
+Update ${ACTIVE_STATUS}:
+- Set top-level status to "completed"
+- Set completed_at to current ISO timestamp
+EOF
+      exit 2
+    fi
+    ;;
+
+  *"Initialize workspace"*)
+    if [ ! -d "$FEEDBACK_DIR" ]; then
+      cat >&2 <<EOF
+Cannot complete "Initialize workspace" task: workspace feedback directory does not exist.
+
+Create the workspace directory structure:
+  mkdir -p ${ACTIVE_WORKSPACE}/{discovery,planning,execution/changes,validation,feedback}
+EOF
+      exit 2
+    fi
+    ;;
+esac
+
+# All checks passed (or task type not enforced)
+exit 0

--- a/plugins/pas/library/orchestration/discussion.md
+++ b/plugins/pas/library/orchestration/discussion.md
@@ -34,6 +34,7 @@ The orchestrator does NOT assign tasks or direct output. Instead:
 5. Moderator synthesizes and proposes conclusion
 6. Agents confirm or raise final objections
 7. Moderator records the outcome
+8. Moderator verifies key claims against source code (read referenced files, check line numbers, confirm behavior) before recording the outcome. Treat agent reports as leads to investigate, not established facts.
 
 ## Status Tracking
 

--- a/plugins/pas/library/orchestration/hub-and-spoke.md
+++ b/plugins/pas/library/orchestration/hub-and-spoke.md
@@ -165,6 +165,8 @@ Gates are checkpoints where the process pauses for review. Behavior depends on t
    - Question: answer, then re-present gate
    - Instruction: incorporate, then continue
 
+**Claim verification:** Before presenting output at a gate, verify key agent claims against source code. Read referenced files, check stated behaviors, confirm line numbers. Treat agent reports as leads to investigate, not established facts. The product owner should never be the first to catch an unverified claim.
+
 **When `gates: advisory` (autonomous mode):**
 - Log gate results to status.yaml but do not pause
 - Orchestrator self-reviews at each gate point


### PR DESCRIPTION
## Summary

- **Fix feedback file deletion (closes #13):** `route-feedback.sh` was unconditionally deleting feedback `.md` files after routing signals. Replaced `rm` with `.routed` sidecar markers for idempotency — feedback files now persist as permanent workspace records.
- **Extract shared workspace utility:** Deduplicated identical 3-line workspace detection pattern from all 5 hooks into `hooks/lib/workspace.sh` (~49 lines saved, 75% reduction in workspace detection code).
- **Add claim verification to orchestration patterns:** Added verification step to `discussion.md` (step 8) and `hub-and-spoke.md` (Claim verification paragraph) — orchestrator must verify agent claims against source code before presenting gate summaries (resolves OQI-02).

## Test plan

- [ ] `bash -n` passes for all 6 scripts (`lib/workspace.sh` + 5 hooks)
- [ ] `route-feedback.sh` no longer contains any `rm` commands
- [ ] All 5 hooks source `lib/workspace.sh` via `SCRIPT_DIR`
- [ ] Functional test: `source lib/workspace.sh && find_active_workspace_status workspace` returns correct `status.yaml` path
- [ ] Verification language present in `discussion.md` step 8 and `hub-and-spoke.md` Gate Protocol
- [ ] No regressions: all hook guards, error messages, and exit codes unchanged