### PR TITLE
Wire up hooks, ship orchestration library and self-eval updates

### DIFF
--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -61,9 +61,16 @@ if [ -n "$AGENT_TRANSCRIPT" ] && [ -f "$AGENT_TRANSCRIPT" ]; then
   fi
 fi
 
-# No self-eval found — log warning with agent_id
-WARNINGS_DIR="$CWD/feedback"
-mkdir -p "$WARNINGS_DIR"
-echo "[$(date -Iseconds)] WARNING: Agent '$AGENT_ID' shutdown without writing self-eval to $FEEDBACK_DIR" >> "$WARNINGS_DIR/warnings.log"
+# No self-eval found — block subagent from stopping
+cat >&2 <<EOF
+SELF-EVALUATION MISSING
 
-exit 0
+Agent '${AGENT_ID}' is shutting down without writing self-evaluation.
+
+Before stopping, write your self-evaluation to:
+  ${FEEDBACK_DIR}/${AGENT_ID}.md
+
+Use library/self-evaluation/SKILL.md for the format.
+If nothing went wrong, write "No issues detected."
+EOF
+exit 2

--- a/plugins/pas/hooks/hooks.json
+++ b/plugins/pas/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pas-session-start.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "hooks": [
@@ -11,7 +22,27 @@
         ]
       }
     ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-task-completion.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-completion-gate.sh",
+            "timeout": 10
+          }
+        ]
+      },
       {
         "hooks": [
           {

--- a/plugins/pas/library/orchestration/changelog.md
+++ b/plugins/pas/library/orchestration/changelog.md
@@ -1,5 +1,26 @@
 # Orchestration Library Changelog
 
+## 2026-03-07 — Add task creation and hook enforcement references
+
+Triggered by: GitHub issue #7 — orchestrator does not self-enforce process lifecycle
+Pattern: Text-level enforcement (HARD REQUIREMENT, COMPLETION GATE) still skipped by orchestrator
+Changes:
+- All 4 patterns: Add task creation step at startup — [PAS]-prefixed tasks for phases + shutdown
+- All 4 patterns: Add hook enforcement note under COMPLETION GATE
+- hub-and-spoke.md: Add session tracking fields (current_session, sessions) to status.yaml format
+
+## 2026-03-07 — Fix feedback system: mandatory workspace, completion gates
+
+Triggered by: GitHub issue #6 — 2/2 sessions completed without feedback, workspace never created, self-eval never written
+Pattern: Passive language ("check for workspace") allowed orchestrators to skip workspace creation entirely; no structural enforcement of feedback at shutdown
+Changes:
+- All 4 patterns: Rewrite workspace init from "check for" to imperative "create" with HARD REQUIREMENT callout
+- All 4 patterns: Add COMPLETION GATE with 4 blocking conditions (phases complete, feedback files exist, framework signals filed, status finalized)
+- hub-and-spoke.md: Add orchestrator self-eval step (step 6), framework signal routing (step 7)
+- solo.md: Add framework signal routing step, COMPLETION GATE
+- discussion.md: Replace "follows hub-and-spoke" with explicit Startup (4 steps) and Shutdown (8 steps) sections
+- sequential-agents.md: Add new Startup (4 steps) and Shutdown (8 steps) sections that were missing entirely
+
 ## 2026-03-07 — Enforce self-evaluation, add agent communication guidance
 
 Triggered by: GitHub issue #1 — Self-eval skipped 3x across 2 sessions, wrong communication mechanism used

--- a/plugins/pas/library/orchestration/discussion.md
+++ b/plugins/pas/library/orchestration/discussion.md
@@ -53,11 +53,65 @@ phases:
     notes: "Consensus reached on moderate risk with mitigation."
 ```
 
-## Spawning and Shutdown
+## Startup Sequence
 
-- Spawn all discussion participants via TeamCreate at discussion start
-- All agents stay alive for the full discussion (they need prior round context)
-- Shutdown follows the same sequence as hub-and-spoke (downstream feedback, self-eval, shutdown together)
+1. **Read process.md** to load the discussion topic, participants, and expected output format
+2. **Read mode file** (`modes/{mode}.md`) to determine gate behavior
+3. **Create workspace** — this is a HARD REQUIREMENT, not optional
+
+   ```bash
+   mkdir -p workspace/{process}/{slug}/discovery
+   mkdir -p workspace/{process}/{slug}/planning
+   mkdir -p workspace/{process}/{slug}/execution/changes
+   mkdir -p workspace/{process}/{slug}/validation
+   mkdir -p workspace/{process}/{slug}/feedback
+   ```
+
+   Write `workspace/{process}/{slug}/status.yaml` with all discussion rounds as `pending`, `started_at` timestamp, and `status: in_progress`.
+
+   Do NOT proceed to step 4 until the workspace directory and status.yaml exist on disk.
+
+   3a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed round. Do not re-create the workspace.
+
+4. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
+
+   For each phase in process.md:
+   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
+
+   Shutdown tasks (always created):
+   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
+   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
+   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
+
+   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
+
+5. **Spawn all discussion participants** via TeamCreate
+
+## Shutdown Sequence
+
+When the discussion is complete:
+
+1. **Verify synthesis** and all output files exist
+2. **Send downstream feedback** to each participant: share how their contributions were used in the final synthesis
+3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`
+4. **All agents shut down together** after self-evaluation completes
+5. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`
+6. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository
+7. **Verify all feedback signals** have been routed to their destinations
+8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps
+
+### COMPLETION GATE
+
+Before declaring the session complete, ALL of the following MUST be true:
+
+1. All rounds/phases have `status: completed` in status.yaml
+2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
+3. All signals with target `framework:pas` have been filed as GitHub issues
+4. `status.yaml` has `completed_at` timestamp and `status: completed`
+
+If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
+
+**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.
 
 ## Gate Protocol
 

--- a/plugins/pas/library/orchestration/hub-and-spoke.md
+++ b/plugins/pas/library/orchestration/hub-and-spoke.md
@@ -11,12 +11,36 @@ The default pattern for multi-agent processes. A central orchestrator reads the 
 
 1. **Read process.md** to load the process definition (phases, agents, I/O dependencies, gates)
 2. **Read mode file** (`modes/{mode}.md`) to determine gate behavior
-3. **Check for existing workspace** at `workspace/{process}/{slug}/status.yaml`
-   - If status.yaml exists: resume from last completed phase (see Resumability below)
-   - If no status.yaml: create workspace, initialize status.yaml with all phases as `pending`
-4. **Load orchestration skills**: read this file for execution rules
-5. **When feedback is enabled**: carry `library/self-evaluation/SKILL.md` for shutdown
-6. **Spawn team members** via TeamCreate for all specialist agents defined in process.md
+3. **Create workspace** — this is a HARD REQUIREMENT, not optional
+
+   ```bash
+   mkdir -p workspace/{process}/{slug}/discovery
+   mkdir -p workspace/{process}/{slug}/planning
+   mkdir -p workspace/{process}/{slug}/execution/changes
+   mkdir -p workspace/{process}/{slug}/validation
+   mkdir -p workspace/{process}/{slug}/feedback
+   ```
+
+   Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
+
+   Do NOT proceed to step 4 until the workspace directory and status.yaml exist on disk.
+
+   3a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase (see Resumability below). Do not re-create the workspace.
+4. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
+
+   For each phase in process.md:
+   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
+
+   Shutdown tasks (always created):
+   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
+   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
+   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
+
+   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
+
+5. **Load orchestration skills**: read this file for execution rules
+6. **When feedback is enabled**: carry `library/self-evaluation/SKILL.md` for shutdown
+7. **Spawn team members** via TeamCreate for all specialist agents defined in process.md
 
 ## Spawning Team Members
 
@@ -118,6 +142,7 @@ instance: {slug}
 started_at: {ISO timestamp}
 completed_at: ~
 status: in_progress
+current_session: {first 8 chars of session_id}
 
 phases:
   {phase-name}:
@@ -132,7 +157,15 @@ phases:
     quality:
       score: {1-10}
       notes: "{free text assessment}"
+
+sessions:
+  - id: {short session_id}
+    started_at: {ISO timestamp}
+    completed_at: {ISO timestamp or ~}
+    feedback_collected: {true or false}
 ```
+
+**Session tracking:** The `pas-session-start.sh` hook automatically writes `current_session` and appends to the `sessions` list when a session begins. Feedback files are named `feedback/orchestrator-{session_id}.md` so the Stop hook can verify that THIS session (not a previous one) produced feedback.
 
 Sub-processes write their own status.yaml. Parent references via `subprocess: {path}/status.yaml`.
 
@@ -181,7 +214,22 @@ When all phases are complete:
 3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). This is mandatory — do NOT proceed to step 4 until all agents have written their feedback. Self-evaluation instructions must be included in every agent spawn prompt (see Spawning Team Members above). Agents have full work context at this point, making evaluations rich and specific. Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`
 4. **All agents shut down together** after self-evaluation completes
 5. **Verify all feedback signals** have been routed to their destinations (GitHub issues, artifact backlogs, etc.) before declaring session complete
-6. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps and quality scores
+6. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`. The orchestrator is an agent too — it observes issues that team members cannot (coordination failures, gate misjudgments, process-level problems). Do NOT skip this step.
+7. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository. Do not leave framework signals in local feedback files only.
+8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps and quality scores
+
+### COMPLETION GATE
+
+Before declaring the session complete, ALL of the following MUST be true:
+
+1. All phases have `status: completed` in status.yaml
+2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
+3. All signals with target `framework:pas` have been filed as GitHub issues
+4. `status.yaml` has `completed_at` timestamp and `status: completed`
+
+If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
+
+**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.
 
 ## Resumability
 

--- a/plugins/pas/library/orchestration/sequential-agents.md
+++ b/plugins/pas/library/orchestration/sequential-agents.md
@@ -14,6 +14,66 @@ Agents execute one at a time in strict order. The orchestrator manages handoff b
 - Assembly-line workflows where each agent transforms the previous agent's output
 - Processes where context from phase N is critical to phase N+1 and must be passed explicitly
 
+## Startup Sequence
+
+1. **Read process.md** to load the process definition (phases, agents, handoff requirements)
+2. **Read mode file** (`modes/{mode}.md`) to determine gate behavior
+3. **Create workspace** — this is a HARD REQUIREMENT, not optional
+
+   ```bash
+   mkdir -p workspace/{process}/{slug}/discovery
+   mkdir -p workspace/{process}/{slug}/planning
+   mkdir -p workspace/{process}/{slug}/execution/changes
+   mkdir -p workspace/{process}/{slug}/validation
+   mkdir -p workspace/{process}/{slug}/feedback
+   ```
+
+   Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
+
+   Do NOT proceed to step 4 until the workspace directory and status.yaml exist on disk.
+
+   3a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase. Do not re-create the workspace.
+
+4. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
+
+   For each phase in process.md:
+   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
+
+   Shutdown tasks (always created):
+   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
+   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
+   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
+
+   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
+
+5. **Spawn first agent** via TeamCreate with handoff context
+
+## Shutdown Sequence
+
+When all phases are complete:
+
+1. **Verify all output files** exist for all phases
+2. **Send downstream feedback** to agents still alive: share relevant quality notes from later phases
+3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`
+4. **All remaining agents shut down** after self-evaluation completes
+5. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`
+6. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository
+7. **Verify all feedback signals** have been routed to their destinations
+8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps
+
+### COMPLETION GATE
+
+Before declaring the session complete, ALL of the following MUST be true:
+
+1. All phases have `status: completed` in status.yaml
+2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
+3. All signals with target `framework:pas` have been filed as GitHub issues
+4. `status.yaml` has `completed_at` timestamp and `status: completed`
+
+If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
+
+**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.
+
 ## Handoff Protocol
 
 When one agent completes and the next begins:

--- a/plugins/pas/library/orchestration/solo.md
+++ b/plugins/pas/library/orchestration/solo.md
@@ -19,11 +19,38 @@ The simplest pattern. The orchestrator is the only agent and handles all phases 
 The orchestrator reads process.md and executes phases sequentially using its own skills. It:
 
 1. Reads the process definition and mode file
-2. Checks for existing workspace (resumability, same as hub-and-spoke)
-3. Executes each phase by reading the relevant skill from its own `skills/` directory
-4. Writes output to workspace
-5. Handles gates (if supervised mode)
-6. Updates status.yaml after each phase
+2. **Create workspace** — this is a HARD REQUIREMENT, not optional
+
+   ```bash
+   mkdir -p workspace/{process}/{slug}/discovery
+   mkdir -p workspace/{process}/{slug}/planning
+   mkdir -p workspace/{process}/{slug}/execution/changes
+   mkdir -p workspace/{process}/{slug}/validation
+   mkdir -p workspace/{process}/{slug}/feedback
+   ```
+
+   Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
+
+   Do NOT proceed to step 3 until the workspace directory and status.yaml exist on disk.
+
+   2a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase. Do not re-create the workspace.
+
+3. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
+
+   For each phase in process.md:
+   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
+
+   Shutdown tasks (always created):
+   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
+   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
+   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
+
+   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
+
+4. Executes each phase by reading the relevant skill from its own `skills/` directory
+5. Writes output to workspace
+6. Handles gates (if supervised mode)
+7. Updates status.yaml after each phase
 
 No TeamCreate calls. No Agent tool delegation. If the orchestrator needs parallel subtask execution, it can spawn ephemeral subagents via the Agent tool, but these are fire-and-forget helpers, not team members.
 
@@ -43,5 +70,19 @@ Same format as hub-and-spoke. The `agent` field for every phase is `orchestrator
 
 1. All phases complete — verify all output files exist
 2. **Mandatory self-evaluation checkpoint**: If feedback is enabled in `pas-config.yaml`, read `library/self-evaluation/SKILL.md` and write feedback to `workspace/{process}/{slug}/feedback/orchestrator.md`. Do NOT skip this step. Do NOT declare the session complete until self-evaluation is written.
-3. Verify all feedback signals have been routed to their destinations (GitHub issues, artifact backlogs, etc.) before declaring session complete
-4. Finalize status.yaml
+3. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository. Do not leave framework signals in local feedback files only.
+4. Verify all feedback signals have been routed to their destinations (GitHub issues, artifact backlogs, etc.) before declaring session complete
+5. Finalize status.yaml
+
+### COMPLETION GATE
+
+Before declaring the session complete, ALL of the following MUST be true:
+
+1. All phases have `status: completed` in status.yaml
+2. Feedback file exists at `workspace/{process}/{slug}/feedback/orchestrator.md`
+3. All signals with target `framework:pas` have been filed as GitHub issues
+4. `status.yaml` has `completed_at` timestamp and `status: completed`
+
+If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
+
+**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.

--- a/plugins/pas/library/self-evaluation/SKILL.md
+++ b/plugins/pas/library/self-evaluation/SKILL.md
@@ -19,7 +19,9 @@ Do NOT activate during work. Do NOT evaluate while producing output. Wait until 
 
 1. Reflect on the session: what went well, what went wrong, what the user corrected
 2. For each observation, determine the signal type (see below)
-3. Write signals to `workspace/{process}/{slug}/feedback/{your-agent-name}.md`
+3. Write signals to `workspace/{process}/{slug}/feedback/{your-agent-name}-{session_id}.md`
+
+   The session ID is provided by the SessionStart hook and recorded in `status.yaml` under `current_session`. If no session ID is available, use your agent name without a suffix.
 4. If nothing went wrong: write "No issues detected." and stop. Do NOT list positives.
 
 ## Signal Types
@@ -83,12 +85,30 @@ Context: {what made this session risky for this behavior}
 - `agent:{name}` — targets agent-level behavior
 - `process:{name}` — targets process-level definition
 
+**Additional target:** `framework:pas` — targets the PAS framework itself (not a specific process artifact). See Framework Feedback Routing below.
+
 **Signal ID format:** `[TYPE-NN]` where NN is sequential within the file (e.g., `[PPU-01]`, `[OQI-01]`, `[OQI-02]`).
 
 **Priority levels:**
 - HIGH: user explicitly corrected this, or output was factually wrong
 - MEDIUM: suboptimal output that the user noticed
 - LOW: minor inefficiency or style issue
+
+## Framework Feedback Routing
+
+When a signal targets the PAS framework itself (not a specific process, agent, or skill), use `Target: framework:pas`. This applies when:
+
+- A PAS convention is missing or broken
+- An orchestration pattern has a structural gap
+- The feedback system itself has a deficiency
+- A library skill needs improvement
+
+**Routing chain:**
+1. Agent writes the signal locally to `workspace/{process}/{slug}/feedback/{agent-name}.md` with `Target: framework:pas`
+2. Agent appends `Route: github-issue` to the signal block
+3. At shutdown, the orchestrator reads all feedback files, finds signals marked `Route: github-issue`, and files them as GitHub issues on the PAS repository
+
+The agent's job is to detect and record the signal. The orchestrator's job is to route it. The COMPLETION GATE (in the orchestration pattern) blocks session completion until all `framework:pas` signals have been filed.
 
 ## Saturation Prevention
 


### PR DESCRIPTION
## Summary

- Register SessionStart, TaskCompleted, and verify-completion-gate hooks in hooks.json — the scripts were shipped in PRs #15/#16 but never wired up, so they never fired
- Upgrade check-self-eval.sh from warning-log to blocking (exit 2) so agents can't skip self-evaluation
- Ship orchestration library overhaul: full turn-taking protocol, parallel dispatch, shutdown sequence, new sequential-agents pattern
- Update self-evaluation SKILL.md with signal format improvements

These are plugin changes that were committed to dev across cycles 4-5 but missed PRs #15 and #16. This PR closes the gap between dev and main for `plugins/pas/`.

## Test plan

- [ ] Verify hooks.json registers all 4 hook events (SessionStart, SubagentStop, TaskCompleted, Stop)
- [ ] Verify check-self-eval.sh exits 2 (blocking) instead of 0 (warning)
- [ ] Confirm orchestration library files match dev versions