### PR TITLE
Lifecycle extraction, DX quick wins, ready-handshake

### DIFF
--- a/plugins/pas/library/orchestration/SKILL.md
+++ b/plugins/pas/library/orchestration/SKILL.md
@@ -7,6 +7,10 @@ description: Decision guide for selecting the right orchestration pattern for a 
 
 Every process declares an `orchestration:` field in its process.md. This guide helps you choose the right pattern.
 
+## Terminology
+
+- **Slug**: A short identifier for a process run instance (e.g., `cycle-9`, `2026-03-08-code-review`). The slug is provided by the user or derived from the directive when the orchestrator creates the workspace.
+
 ## Available Patterns
 
 | Pattern | File | Orchestrator Role | Best For |
@@ -35,14 +39,21 @@ Every process declares an `orchestration:` field in its process.md. This guide h
 4. **Still unsure?**
    - Default to **hub-and-spoke**. It handles both parallel and sequential phases, and the orchestrator can infer execution order from I/O dependencies.
 
+## Shared Lifecycle
+
+All patterns share a common lifecycle protocol defined in `lifecycle.md`:
+- Workspace creation, lifecycle task creation, status tracking format
+- Ready-handshake protocol for agent spawn timing
+- Shutdown sequence, completion gate, session continuity, resumability
+
+Read `lifecycle.md` first, then the pattern-specific file for execution rules.
+
 ## Pattern Details
 
-Read the individual pattern file for execution rules:
-
-- `hub-and-spoke.md` — Spawn order, parallelism inference, status tracking, error chain, shutdown sequence, gate protocol, resumability
+- `hub-and-spoke.md` — Spawn order, parallelism inference, error chain, gate protocol, intra-phase parallel dispatch
 - `discussion.md` — Moderator behavior, turn-taking, synthesis rules
 - `solo.md` — Single-agent operation, when to upgrade to multi-agent
-- `sequential-agents.md` — Handoff protocol, status updates between agents
+- `sequential-agents.md` — Handoff protocol, agent lifecycle (eager shutdown)
 
 ## Overriding Defaults
 

--- a/plugins/pas/library/orchestration/changelog.md
+++ b/plugins/pas/library/orchestration/changelog.md
@@ -1,5 +1,17 @@
 # Orchestration Library Changelog
 
+## 2026-03-08 — Extract shared lifecycle protocol + ready-handshake
+
+Triggered by: Cycle 9 Milestone 1 — orchestration pattern duplication (~300 of 578 lines identical)
+Pattern: Every bug fix applied 4x across patterns; agent spawn timing race unfixed for 3 cycles
+Changes:
+- Created `lifecycle.md`: shared protocol for workspace creation, task creation, status tracking, ready-handshake, shutdown sequence, completion gate, session continuity, resumability
+- hub-and-spoke.md: replaced duplicated lifecycle sections with references to lifecycle.md (250 -> ~140 lines). Added ready-handshake to spawn prompt requirements.
+- discussion.md: replaced duplicated lifecycle sections with references to lifecycle.md (122 -> ~60 lines). Added ready-handshake to spawn step.
+- solo.md: replaced duplicated lifecycle sections with references to lifecycle.md (92 -> ~40 lines). No ready-handshake (no agents spawned).
+- sequential-agents.md: replaced duplicated lifecycle sections with references to lifecycle.md (114 -> ~65 lines). Added ready-handshake to spawn and handoff steps.
+- Ready-handshake protocol: agents send `READY: {name}` after spawn, orchestrator waits before dispatching work. Mitigates TeamCreate spawn timing race.
+
 ## 2026-03-07 — Add task creation and hook enforcement references
 
 Triggered by: GitHub issue #7 — orchestrator does not self-enforce process lifecycle

--- a/plugins/pas/library/orchestration/discussion.md
+++ b/plugins/pas/library/orchestration/discussion.md
@@ -38,7 +38,7 @@ The orchestrator does NOT assign tasks or direct output. Instead:
 
 ## Status Tracking
 
-Same format as hub-and-spoke, but phases map to discussion rounds rather than production stages:
+Same format as `lifecycle.md` > Status Tracking, but phases map to discussion rounds rather than production stages:
 
 ```yaml
 phases:
@@ -57,62 +57,18 @@ phases:
 
 1. **Read process.md** to load the discussion topic, participants, and expected output format
 2. **Read mode file** (`modes/{mode}.md`) to determine gate behavior
-3. **Create workspace** — this is a HARD REQUIREMENT, not optional
-
-   ```bash
-   mkdir -p workspace/{process}/{slug}/discovery
-   mkdir -p workspace/{process}/{slug}/planning
-   mkdir -p workspace/{process}/{slug}/execution/changes
-   mkdir -p workspace/{process}/{slug}/validation
-   mkdir -p workspace/{process}/{slug}/feedback
-   ```
-
-   Write `workspace/{process}/{slug}/status.yaml` with all discussion rounds as `pending`, `started_at` timestamp, and `status: in_progress`.
-
-   Do NOT proceed to step 4 until the workspace directory and status.yaml exist on disk.
-
-   3a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed round. Do not re-create the workspace.
-
-4. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
-
-   For each phase in process.md:
-   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
-
-   Shutdown tasks (always created):
-   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
-   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
-   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
-
-   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
-
-5. **Spawn all discussion participants** via TeamCreate
-
-## Shutdown Sequence
-
-When the discussion is complete:
-
-1. **Verify synthesis** and all output files exist
-2. **Send downstream feedback** to each participant: share how their contributions were used in the final synthesis
-3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`
-4. **All agents shut down together** after self-evaluation completes
-5. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`
-6. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository
-7. **Verify all feedback signals** have been routed to their destinations
-8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps
-
-### COMPLETION GATE
-
-Before declaring the session complete, ALL of the following MUST be true:
-
-1. All rounds/phases have `status: completed` in status.yaml
-2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
-3. All signals with target `framework:pas` have been filed as GitHub issues
-4. `status.yaml` has `completed_at` timestamp and `status: completed`
-
-If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
-
-**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.
+3. **Create workspace** -- follow `lifecycle.md` > Workspace Creation
+4. **Create lifecycle tasks** -- follow `lifecycle.md` > Lifecycle Task Creation
+5. **Spawn all discussion participants** via TeamCreate. Follow `lifecycle.md` > Ready Handshake -- wait for all agents to confirm READY before beginning the discussion.
 
 ## Gate Protocol
 
 In supervised mode, the moderator presents the synthesis to the user at each gate rather than raw agent outputs. The user can redirect the discussion or approve the synthesis.
+
+## Shutdown, Completion Gate, Session Continuity, Resumability
+
+Follow `lifecycle.md` for:
+- **Shutdown Sequence** (steps 1-8)
+- **Completion Gate** (4 conditions + hook enforcement)
+- **Session Continuity** (offer next cycle)
+- **Resumability** (resume from status.yaml)

--- a/plugins/pas/library/orchestration/hub-and-spoke.md
+++ b/plugins/pas/library/orchestration/hub-and-spoke.md
@@ -11,36 +11,11 @@ The default pattern for multi-agent processes. A central orchestrator reads the 
 
 1. **Read process.md** to load the process definition (phases, agents, I/O dependencies, gates)
 2. **Read mode file** (`modes/{mode}.md`) to determine gate behavior
-3. **Create workspace** — this is a HARD REQUIREMENT, not optional
-
-   ```bash
-   mkdir -p workspace/{process}/{slug}/discovery
-   mkdir -p workspace/{process}/{slug}/planning
-   mkdir -p workspace/{process}/{slug}/execution/changes
-   mkdir -p workspace/{process}/{slug}/validation
-   mkdir -p workspace/{process}/{slug}/feedback
-   ```
-
-   Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
-
-   Do NOT proceed to step 4 until the workspace directory and status.yaml exist on disk.
-
-   3a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase (see Resumability below). Do not re-create the workspace.
-4. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
-
-   For each phase in process.md:
-   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
-
-   Shutdown tasks (always created):
-   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
-   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
-   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
-
-   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
-
+3. **Create workspace** -- follow `lifecycle.md` > Workspace Creation
+4. **Create lifecycle tasks** -- follow `lifecycle.md` > Lifecycle Task Creation
 5. **Load orchestration skills**: read this file for execution rules
 6. **When feedback is enabled**: carry `library/self-evaluation/SKILL.md` for shutdown
-7. **Spawn team members** via TeamCreate for all specialist agents defined in process.md
+7. **Spawn team members** via TeamCreate for all specialist agents defined in process.md. Follow `lifecycle.md` > Ready Handshake -- wait for all agents to confirm READY before dispatching work.
 
 ## Spawning Team Members
 
@@ -52,6 +27,7 @@ Use TeamCreate for each specialist agent. The spawn prompt tells them:
 - Where to write output: "Write output to `workspace/{process}/{slug}/{output-folder}/`"
 - Feedback status: whether self-evaluation is active
 - Self-evaluation instructions: "Before returning your final result, if feedback is enabled in `pas-config.yaml`, read `library/self-evaluation/SKILL.md` and write feedback to `workspace/{process}/{slug}/feedback/{your-name}.md`"
+- Ready handshake: "After reading your agent.md and skills, send a message to the orchestrator containing only: `READY: {agent-name}`"
 
 Team members persist for the full process lifecycle. They retain work context for richer self-evaluation and can receive downstream feedback from later phases. Idle agents cost zero tokens.
 
@@ -105,7 +81,7 @@ When an agent needs to split work within a single phase across multiple parallel
 
 Every subagent spawn prompt MUST include:
 
-1. **Verified file paths**: Before dispatching, confirm all referenced paths exist. Do not propagate paths without verification — a wrong path in the spawn prompt will be replicated across all subagent work.
+1. **Verified file paths**: Before dispatching, confirm all referenced paths exist. Do not propagate paths without verification -- a wrong path in the spawn prompt will be replicated across all subagent work.
 2. **Specific scope**: One clear objective per agent. "Fix link-building skill" not "fix all skills."
 3. **Output location**: Exact path for writing results to `workspace/{process}/{slug}/`
 4. **Shutdown protocol**: "When your task is complete: 1) Write your self-evaluation, 2) Return your summary. Do not shut down before completing self-evaluation."
@@ -118,9 +94,9 @@ Every subagent spawn prompt MUST include:
 - Short-lived tasks ("it was quick" is not a reason to skip)
 - Ad-hoc agents spawned outside the original process design
 
-A smooth task with no issues produces "No issues detected." — which is still valuable confirmation.
+A smooth task with no issues produces "No issues detected." -- which is still valuable confirmation.
 
-### Completion Gate
+### Dispatch Completion Gate
 
 The dispatching agent (orchestrator or team member) must:
 
@@ -128,46 +104,6 @@ The dispatching agent (orchestrator or team member) must:
 2. Do not declare the dispatch complete until every subagent has written feedback
 3. Review results for conflicts (did agents edit the same files?)
 4. Run verification (tests, cross-checks) after integrating all results
-
-## Status Tracking
-
-Write `workspace/{process}/{slug}/status.yaml` continuously at every state change. Status is a performance log, not just state.
-
-**Valid states:** `pending`, `in_progress`, `completed`. Add process-specific states only when the user requests them.
-
-**Format per phase:**
-```yaml
-process: {name}
-instance: {slug}
-started_at: {ISO timestamp}
-completed_at: ~
-status: in_progress
-current_session: {first 8 chars of session_id}
-
-phases:
-  {phase-name}:
-    status: completed
-    agent: {agent-name}
-    started_at: {ISO timestamp}
-    completed_at: {ISO timestamp}
-    duration_seconds: {number}
-    attempts: {number}
-    output_files:
-      - {path relative to workspace}
-    quality:
-      score: {1-10}
-      notes: "{free text assessment}"
-
-sessions:
-  - id: {short session_id}
-    started_at: {ISO timestamp}
-    completed_at: {ISO timestamp or ~}
-    feedback_collected: {true or false}
-```
-
-**Session tracking:** The `pas-session-start.sh` hook automatically writes `current_session` and appends to the `sessions` list when a session begins. Feedback files are named `feedback/orchestrator-{session_id}.md` so the Stop hook can verify that THIS session (not a previous one) produced feedback.
-
-Sub-processes write their own status.yaml. Parent references via `subprocess: {path}/status.yaml`.
 
 ## Error Handling Chain
 
@@ -205,42 +141,11 @@ Gates are checkpoints where the process pauses for review. Behavior depends on t
 - Orchestrator self-reviews at each gate point
 - Flag critical issues for user attention even in autonomous mode
 
-## Shutdown Sequence
+## Shutdown, Completion Gate, Session Continuity, Resumability
 
-When all phases are complete:
-
-1. **Complete all phases** and verify all output files exist
-2. **Send downstream feedback** to each team member: share relevant quality notes from later phases (e.g., tell researcher what the journalist struggled with)
-3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). This is mandatory — do NOT proceed to step 4 until all agents have written their feedback. Self-evaluation instructions must be included in every agent spawn prompt (see Spawning Team Members above). Agents have full work context at this point, making evaluations rich and specific. Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`
-4. **All agents shut down together** after self-evaluation completes
-5. **Verify all feedback signals** have been routed to their destinations (GitHub issues, artifact backlogs, etc.) before declaring session complete
-6. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`. The orchestrator is an agent too — it observes issues that team members cannot (coordination failures, gate misjudgments, process-level problems). Do NOT skip this step.
-7. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository. Do not leave framework signals in local feedback files only.
-8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps and quality scores
-
-### COMPLETION GATE
-
-Before declaring the session complete, ALL of the following MUST be true:
-
-1. All phases have `status: completed` in status.yaml
-2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
-3. All signals with target `framework:pas` have been filed as GitHub issues
-4. `status.yaml` has `completed_at` timestamp and `status: completed`
-
-If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
-
-**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.
-
-## Resumability
-
-If a session is interrupted (context limits, user leaves, crash):
-
-1. On next session start, read `workspace/{process}/{slug}/status.yaml`
-2. Identify last completed phase and current in_progress phase
-3. For in_progress phases: check if output files exist and are complete
-   - If complete but not marked: mark as completed, proceed
-   - If partial: move to `partial/`, restart the phase
-4. Resume from next pending phase
-5. Re-spawn team members as needed (they don't persist across sessions)
-
-The orchestrator is responsible for completing the process to a high degree of quality regardless of how many sessions it takes.
+Follow `lifecycle.md` for:
+- **Shutdown Sequence** (steps 1-8)
+- **Completion Gate** (4 conditions + hook enforcement)
+- **Session Continuity** (offer next cycle)
+- **Resumability** (resume from status.yaml)
+- **Status Tracking** (status.yaml format and session tracking)

--- a/plugins/pas/library/orchestration/lifecycle.md
+++ b/plugins/pas/library/orchestration/lifecycle.md
@@ -1,0 +1,141 @@
+---
+name: lifecycle
+description: Shared lifecycle protocol for all orchestration patterns. Covers workspace, tasks, status, shutdown, completion gate, resumability, and agent ready-handshake.
+---
+
+# Lifecycle Protocol
+
+Every orchestration pattern shares this lifecycle protocol. Pattern-specific files (hub-and-spoke, discussion, solo, sequential-agents) define only their unique behavior and reference this file for shared protocol.
+
+## Workspace Creation
+
+This is a **HARD REQUIREMENT**, not optional. Do NOT proceed to any subsequent startup step until the workspace directory and status.yaml exist on disk.
+
+```bash
+mkdir -p workspace/{process}/{slug}/discovery
+mkdir -p workspace/{process}/{slug}/planning
+mkdir -p workspace/{process}/{slug}/execution/changes
+mkdir -p workspace/{process}/{slug}/validation
+mkdir -p workspace/{process}/{slug}/feedback
+```
+
+Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
+
+**If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase (see Resumability below). Do not re-create the workspace.
+
+## Lifecycle Task Creation
+
+Create lifecycle tasks using TaskCreate immediately after workspace creation. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook.
+
+For each phase in process.md:
+- `[PAS] Phase: {phase-name}` -- description: "{agent} processes {input} to produce {output}"
+
+Shutdown tasks (always created):
+- `[PAS] Self-evaluation` -- description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
+- `[PAS] Route framework signals` -- description: "File any framework:pas signals as GitHub issues"
+- `[PAS] Finalize status` -- description: "Set status.yaml status to completed with completed_at timestamp"
+
+Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement -- you cannot mark shutdown tasks complete until their deliverables exist on disk.
+
+## Ready Handshake
+
+When spawning agents via TeamCreate (hub-and-spoke, discussion, sequential-agents patterns), use this protocol to prevent the agent spawn timing race condition where messages sent during spawn are lost.
+
+### Protocol
+
+1. **Include in every spawn prompt**: "After reading your agent.md and skills, send a message to the orchestrator containing only: `READY: {agent-name}`"
+2. **Orchestrator waits** for READY messages from all spawned agents before sending any work instructions
+3. **Probe on timeout**: if an agent does not send READY within a reasonable period, orchestrator sends a probe message: "Confirm you are ready by responding with `READY: {agent-name}`"
+4. **Dispatch only after confirmation**: only after all agents confirm READY does the orchestrator begin phase dispatch or discussion facilitation
+
+### Why This Exists
+
+Agents spawned via TeamCreate read their agent.md before processing their mailbox. Messages sent during spawn are lost. This has been observed in cycle 7, cycle 8, and cycle 9. The ready-handshake ensures the orchestrator does not send work instructions until agents are actually listening.
+
+The solo pattern does not use this protocol since it does not spawn agents.
+
+## Status Tracking
+
+Write `workspace/{process}/{slug}/status.yaml` continuously at every state change. Status is a performance log, not just state.
+
+**Valid states:** `pending`, `in_progress`, `completed`. Add process-specific states only when the user requests them.
+
+**Format:**
+```yaml
+process: {name}
+instance: {slug}
+started_at: {ISO timestamp}
+completed_at: ~
+status: in_progress
+current_session: {first 8 chars of session_id}
+
+phases:
+  {phase-name}:
+    status: completed
+    agent: {agent-name}
+    started_at: {ISO timestamp}
+    completed_at: {ISO timestamp}
+    duration_seconds: {number}
+    attempts: {number}
+    output_files:
+      - {path relative to workspace}
+    quality:
+      score: {1-10}
+      notes: "{free text assessment}"
+
+sessions:
+  - id: {short session_id}
+    started_at: {ISO timestamp}
+    completed_at: {ISO timestamp or ~}
+    feedback_collected: {true or false}
+```
+
+**Session tracking:** The `pas-session-start.sh` hook automatically writes `current_session` and appends to the `sessions` list when a session begins. Feedback files are named `feedback/orchestrator-{session_id}.md` so the Stop hook can verify that THIS session (not a previous one) produced feedback.
+
+Sub-processes write their own status.yaml. Parent references via `subprocess: {path}/status.yaml`.
+
+## Shutdown Sequence
+
+When all phases are complete:
+
+1. **Verify all output files** exist for all phases
+2. **Send downstream feedback** to each team member (if any): share relevant quality notes from later phases
+3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). This is mandatory -- do NOT proceed to step 4 until all agents have written their feedback. Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`
+4. **All agents shut down together** after self-evaluation completes
+5. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`. The orchestrator is an agent too -- it observes issues that team members cannot (coordination failures, gate misjudgments, process-level problems). Do NOT skip this step.
+6. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository. Do not leave framework signals in local feedback files only.
+7. **Verify all feedback signals** have been routed to their destinations (GitHub issues, artifact backlogs, etc.) before declaring session complete
+8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps and quality scores
+
+For solo pattern: steps 2-4 are skipped (no team members). The orchestrator writes its own self-evaluation at step 5.
+
+## Completion Gate
+
+Before declaring the session complete, ALL of the following MUST be true:
+
+1. All phases have `status: completed` in status.yaml
+2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
+3. All signals with target `framework:pas` have been filed as GitHub issues
+4. `status.yaml` has `completed_at` timestamp and `status: completed`
+
+If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
+
+**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net -- follow the shutdown sequence above so it never needs to fire.
+
+## Session Continuity
+
+After the completion gate is satisfied, **always offer the product owner the option to start another cycle.** Ask whether they have a directive for the next cycle or want signal-driven discovery. Do not end the conversation without this offer -- the product owner may want to chain cycles while context is fresh.
+
+## Resumability
+
+If a session is interrupted (context limits, user leaves, crash):
+
+1. On next session start, read `workspace/{process}/{slug}/status.yaml`
+2. Identify last completed phase and current in_progress phase
+3. For in_progress phases: check if output files exist and are complete
+   - If complete but not marked: mark as completed, proceed
+   - If partial: move to `partial/`, restart the phase
+4. Resume from next pending phase
+5. Re-spawn team members as needed (they don't persist across sessions)
+
+The orchestrator is responsible for completing the process to a high degree of quality regardless of how many sessions it takes.

--- a/plugins/pas/library/orchestration/sequential-agents.md
+++ b/plugins/pas/library/orchestration/sequential-agents.md
@@ -18,61 +18,9 @@ Agents execute one at a time in strict order. The orchestrator manages handoff b
 
 1. **Read process.md** to load the process definition (phases, agents, handoff requirements)
 2. **Read mode file** (`modes/{mode}.md`) to determine gate behavior
-3. **Create workspace** — this is a HARD REQUIREMENT, not optional
-
-   ```bash
-   mkdir -p workspace/{process}/{slug}/discovery
-   mkdir -p workspace/{process}/{slug}/planning
-   mkdir -p workspace/{process}/{slug}/execution/changes
-   mkdir -p workspace/{process}/{slug}/validation
-   mkdir -p workspace/{process}/{slug}/feedback
-   ```
-
-   Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
-
-   Do NOT proceed to step 4 until the workspace directory and status.yaml exist on disk.
-
-   3a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase. Do not re-create the workspace.
-
-4. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
-
-   For each phase in process.md:
-   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
-
-   Shutdown tasks (always created):
-   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
-   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
-   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
-
-   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
-
-5. **Spawn first agent** via TeamCreate with handoff context
-
-## Shutdown Sequence
-
-When all phases are complete:
-
-1. **Verify all output files** exist for all phases
-2. **Send downstream feedback** to agents still alive: share relevant quality notes from later phases
-3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`
-4. **All remaining agents shut down** after self-evaluation completes
-5. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`
-6. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository
-7. **Verify all feedback signals** have been routed to their destinations
-8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps
-
-### COMPLETION GATE
-
-Before declaring the session complete, ALL of the following MUST be true:
-
-1. All phases have `status: completed` in status.yaml
-2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
-3. All signals with target `framework:pas` have been filed as GitHub issues
-4. `status.yaml` has `completed_at` timestamp and `status: completed`
-
-If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
-
-**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.
+3. **Create workspace** -- follow `lifecycle.md` > Workspace Creation
+4. **Create lifecycle tasks** -- follow `lifecycle.md` > Lifecycle Task Creation
+5. **Spawn first agent** via TeamCreate with handoff context. Follow `lifecycle.md` > Ready Handshake -- wait for the agent to confirm READY before sending work.
 
 ## Handoff Protocol
 
@@ -81,8 +29,9 @@ When one agent completes and the next begins:
 1. **Current agent completes phase**: writes all output files, updates status.yaml
 2. **Orchestrator verifies output**: checks output files exist and are non-empty
 3. **Orchestrator prepares handoff**: summarizes what the previous agent produced and any quality notes
-4. **Orchestrator spawns next agent**: via TeamCreate with handoff context in the spawn prompt
-5. **Next agent reads input files** and the handoff summary, then begins work
+4. **Orchestrator spawns next agent**: via TeamCreate with handoff context in the spawn prompt. Include READY handshake instruction.
+5. **Wait for READY**, then send handoff summary and work instructions
+6. **Next agent reads input files** and the handoff summary, then begins work
 
 **Handoff summary includes:**
 - What was produced (file list with brief descriptions)
@@ -100,7 +49,7 @@ Unlike hub-and-spoke where all agents persist for the full process, sequential-a
 
 ## Status Tracking
 
-Same format as hub-and-spoke. The `attempts` field is important here since retries involve spawning a fresh agent.
+Same format as `lifecycle.md` > Status Tracking. The `attempts` field is important here since retries involve spawning a fresh agent.
 
 ## Error Handling
 
@@ -112,3 +61,11 @@ Same chain as hub-and-spoke (self-recover, orchestrator retry, escalate). On ret
 ## Gate Protocol
 
 Same as hub-and-spoke. Gates naturally align with handoff points between agents.
+
+## Shutdown, Completion Gate, Session Continuity, Resumability
+
+Follow `lifecycle.md` for:
+- **Shutdown Sequence** (steps 1-8)
+- **Completion Gate** (4 conditions + hook enforcement)
+- **Session Continuity** (offer next cycle)
+- **Resumability** (resume from status.yaml)

--- a/plugins/pas/library/orchestration/solo.md
+++ b/plugins/pas/library/orchestration/solo.md
@@ -19,34 +19,8 @@ The simplest pattern. The orchestrator is the only agent and handles all phases 
 The orchestrator reads process.md and executes phases sequentially using its own skills. It:
 
 1. Reads the process definition and mode file
-2. **Create workspace** — this is a HARD REQUIREMENT, not optional
-
-   ```bash
-   mkdir -p workspace/{process}/{slug}/discovery
-   mkdir -p workspace/{process}/{slug}/planning
-   mkdir -p workspace/{process}/{slug}/execution/changes
-   mkdir -p workspace/{process}/{slug}/validation
-   mkdir -p workspace/{process}/{slug}/feedback
-   ```
-
-   Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
-
-   Do NOT proceed to step 3 until the workspace directory and status.yaml exist on disk.
-
-   2a. **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase. Do not re-create the workspace.
-
-3. **Create lifecycle tasks** using TaskCreate. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook:
-
-   For each phase in process.md:
-   - `[PAS] Phase: {phase-name}` — description: "{agent} processes {input} to produce {output}"
-
-   Shutdown tasks (always created):
-   - `[PAS] Self-evaluation` — description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
-   - `[PAS] Route framework signals` — description: "File any framework:pas signals as GitHub issues"
-   - `[PAS] Finalize status` — description: "Set status.yaml status to completed with completed_at timestamp"
-
-   Mark each task as completed when its work is done. The `[PAS]` prefix triggers hook enforcement — you cannot mark shutdown tasks complete until their deliverables exist on disk.
-
+2. **Create workspace** -- follow `lifecycle.md` > Workspace Creation
+3. **Create lifecycle tasks** -- follow `lifecycle.md` > Lifecycle Task Creation
 4. Executes each phase by reading the relevant skill from its own `skills/` directory
 5. Writes output to workspace
 6. Handles gates (if supervised mode)
@@ -64,25 +38,12 @@ Consider upgrading to hub-and-spoke when:
 
 ## Status Tracking
 
-Same format as hub-and-spoke. The `agent` field for every phase is `orchestrator`.
+Same format as `lifecycle.md` > Status Tracking. The `agent` field for every phase is `orchestrator`.
 
-## Shutdown
+## Shutdown, Completion Gate, Session Continuity, Resumability
 
-1. All phases complete — verify all output files exist
-2. **Mandatory self-evaluation checkpoint**: If feedback is enabled in `pas-config.yaml`, read `library/self-evaluation/SKILL.md` and write feedback to `workspace/{process}/{slug}/feedback/orchestrator.md`. Do NOT skip this step. Do NOT declare the session complete until self-evaluation is written.
-3. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository. Do not leave framework signals in local feedback files only.
-4. Verify all feedback signals have been routed to their destinations (GitHub issues, artifact backlogs, etc.) before declaring session complete
-5. Finalize status.yaml
-
-### COMPLETION GATE
-
-Before declaring the session complete, ALL of the following MUST be true:
-
-1. All phases have `status: completed` in status.yaml
-2. Feedback file exists at `workspace/{process}/{slug}/feedback/orchestrator.md`
-3. All signals with target `framework:pas` have been filed as GitHub issues
-4. `status.yaml` has `completed_at` timestamp and `status: completed`
-
-If any condition is not met, the session is NOT complete. Go back and satisfy the missing condition.
-
-**Hook enforcement:** The `verify-completion-gate.sh` Stop hook enforces conditions 1-2 technically. If you try to stop without writing feedback, the hook will block you and tell you what's missing. The hook is a safety net — follow the shutdown sequence above so it never needs to fire.
+Follow `lifecycle.md` for:
+- **Shutdown Sequence** (steps 1-8; steps 2-4 are skipped since there are no team members)
+- **Completion Gate** (4 conditions + hook enforcement; condition 2 requires only `feedback/orchestrator.md`)
+- **Session Continuity** (offer next cycle)
+- **Resumability** (resume from status.yaml)

--- a/plugins/pas/processes/pas/agents/orchestrator/agent.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/agent.md
@@ -21,7 +21,7 @@ You are the PAS framework assistant. You help users create and manage processes,
 
 ## Behavior
 
-- Use brainstorming-style conversation: one question at a time, crystal clarity before action
+- Use brainstorming-style conversation: one question at a time, ask until the user confirms before acting
 - Never use PAS jargon (process, agent, skill, orchestrator) unless the user uses it first
 - Speak in terms of goals, tasks, and steps
 - Route to the appropriate skill based on user intent:

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md
@@ -73,7 +73,7 @@ When signals conflict with each other:
 Is the feedback clear enough to act on?
 
 - Apply Occam's razor: choose the fix with the fewest assumptions
-- If ambiguous: ask the user for crystal clarity before changing anything
+- If ambiguous: ask the user to clarify before changing anything
 - Never guess at what the user wants. Better to ask than to apply a wrong fix.
 
 ### 8. Apply with Consolidation-First Approach

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
@@ -19,7 +19,7 @@ This skill IS the execution framework. When generating plans for process creatio
 
 ### 1. Clarify the Goal
 
-Apply the crystal clarity principle. Never assume you understand what the user wants.
+Never assume you understand what the user wants. Ask clarifying questions until the user confirms.
 
 - Ask one question at a time, brainstorming-style
 - Probe for: scope, quality expectations, input format, output format, audience

--- a/plugins/pas/processes/pas/changelog.md
+++ b/plugins/pas/processes/pas/changelog.md
@@ -1,5 +1,15 @@
 # PAS Process Changelog
 
+## 2026-03-08 — Remove "crystal clarity" jargon (Cycle 9, Milestone 1)
+
+Triggered by: DX audit — "crystal clarity principle" is internal jargon that adds no value over plain language
+Changes:
+- SKILL.md (entry point) line 25: replaced with "Never assume you understand what the user wants — ask clarifying questions until they confirm."
+- agents/orchestrator/agent.md line 24: replaced with "ask until the user confirms before acting"
+- agents/orchestrator/skills/creating-processes/SKILL.md line 22: replaced with plain instruction
+- agents/orchestrator/skills/applying-feedback/SKILL.md line 76: replaced with "ask the user to clarify"
+- process.md line 34: replaced with "Never assume — ask clarifying questions until the user confirms."
+
 ## 2026-03-07 — Add self-setup, framework feedback mechanism, hook declaration
 
 Triggered by: GitHub issue #1 — No init for new repos, no way to give feedback to PAS itself, hooks never fire

--- a/plugins/pas/processes/pas/process.md
+++ b/plugins/pas/processes/pas/process.md
@@ -31,5 +31,5 @@ Help users create and manage processes, agents, and skills. The orchestrator han
 
 ## Phases
 
-1. **Understand Intent**: Brainstorming-style conversation to clarify what the user wants. Crystal clarity principle: never assume, ask until clear.
+1. **Understand Intent**: Brainstorming-style conversation to clarify what the user wants. Never assume — ask clarifying questions until the user confirms.
 2. **Execute**: Route to the appropriate skill (create process, create agent, create skill, apply feedback) and execute.

--- a/plugins/pas/skills/pas/SKILL.md
+++ b/plugins/pas/skills/pas/SKILL.md
@@ -22,7 +22,7 @@ Based on the user's message, read the appropriate skill from `${CLAUDE_SKILL_DIR
 
 - Brainstorming mode: explore the goal before committing to a solution
 - One question at a time: never ask multiple questions in one message
-- Crystal clarity principle: never assume you understand. Ask until the user confirms.
+- Never assume you understand what the user wants — ask clarifying questions until they confirm.
 - No PAS jargon unless the user uses it first. Speak in terms of goals, tasks, and steps.
 
 ## First-Run Detection

--- a/plugins/pas/skills/pas/changelog.md
+++ b/plugins/pas/skills/pas/changelog.md
@@ -1,0 +1,7 @@
+# /pas Entry Point Skill Changelog
+
+## 2026-03-08 — Remove "crystal clarity" jargon (Cycle 9, Milestone 1)
+
+Triggered by: DX audit — internal jargon replaced with plain language
+Changes:
+- SKILL.md line 25: "Crystal clarity principle: never assume you understand. Ask until the user confirms." replaced with "Never assume you understand what the user wants — ask clarifying questions until they confirm."


### PR DESCRIPTION
## Summary

- Extract shared lifecycle protocol from 4 orchestration patterns into `lifecycle.md` (40% line reduction: 578 → 345 lines, zero duplication)
- Add agent ready-handshake protocol to prevent spawn timing race (unfixed for 3 cycles)
- Remove "crystal clarity" jargon from 5 plugin files, replace with plain language
- Define "slug" terminology in orchestration SKILL.md
- Add changelog entries for DX changes and `/pas` entry point skill
- Rename ambiguous "Completion Gate" → "Dispatch Completion Gate" in hub-and-spoke intra-phase dispatch

Part of Milestone 1 (Foundation & Quick Wins) from the 6-month roadmap.

## Test plan

- [ ] Verify `lifecycle.md` exists and contains: workspace creation, task creation, status tracking, ready-handshake, shutdown sequence, completion gate, session continuity, resumability
- [ ] Verify each pattern file references `lifecycle.md` instead of duplicating shared protocol
- [ ] Verify no pattern file contains `mkdir -p workspace` or `COMPLETION GATE` inline
- [ ] Verify ready-handshake referenced in hub-and-spoke, discussion, sequential-agents spawn sections
- [ ] Verify "crystal clarity" appears nowhere in `plugins/pas/`
- [ ] Verify PPU expansion is consistent
- [ ] Verify "slug" defined in orchestration SKILL.md
- [ ] Verify all modified files have valid YAML frontmatter