### PR TITLE
.pas/ directory convention — consolidate project artifacts

### DIFF
--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -50,7 +50,7 @@ Agent '${AGENT_ID}' is shutting down without writing self-evaluation.
 Before stopping, write your self-evaluation to:
   ${FEEDBACK_DIR}/${AGENT_ID}.md
 
-Use library/self-evaluation/SKILL.md for the format.
+Use .pas/library/self-evaluation/SKILL.md for the format.
 If nothing went wrong, write "No issues detected."
 EOF
 exit 2

--- a/plugins/pas/hooks/lib/guards.sh
+++ b/plugins/pas/hooks/lib/guards.sh
@@ -2,6 +2,9 @@
 # Shared guard functions for PAS hooks.
 # Eliminates duplicated jq/config/feedback checks across hook scripts.
 
+# All PAS project-level artifacts live under this directory.
+PAS_ROOT=".pas"
+
 # Parse JSON input from stdin. Sets CWD and exposes raw INPUT.
 # Returns 1 if jq is missing or JSON is invalid.
 guard_parse_input() {
@@ -18,16 +21,47 @@ guard_parse_input() {
   fi
 }
 
-# Check that this is a PAS project (pas-config.yaml exists).
-# Returns 1 if not a PAS project.
-guard_pas_project() {
-  PAS_CONFIG="$CWD/pas-config.yaml"
-  if [ ! -f "$PAS_CONFIG" ]; then
-    return 1
+# Migrate old-style root-level PAS artifacts into .pas/ directory.
+# Idempotent: skips each item if target already exists.
+migrate_to_pas_dir() {
+  local pas_dir="$CWD/$PAS_ROOT"
+  mkdir -p "$pas_dir"
+
+  # Move config (rename)
+  if [ -f "$CWD/pas-config.yaml" ] && [ ! -f "$pas_dir/config.yaml" ]; then
+    mv "$CWD/pas-config.yaml" "$pas_dir/config.yaml"
   fi
+
+  # Move directories
+  for dir in workspace library processes feedback; do
+    if [ -d "$CWD/$dir" ] && [ ! -d "$pas_dir/$dir" ]; then
+      mv "$CWD/$dir" "$pas_dir/$dir"
+    fi
+  done
 }
 
-# Check that feedback is enabled in pas-config.yaml.
+# Check that this is a PAS project (.pas/config.yaml exists).
+# Auto-migrates old-style layout if detected.
+# Returns 1 if not a PAS project.
+guard_pas_project() {
+  PAS_CONFIG="$CWD/$PAS_ROOT/config.yaml"
+  if [ -f "$PAS_CONFIG" ]; then
+    return 0
+  fi
+
+  # Backward compatibility: migrate old-style root layout
+  if [ -f "$CWD/pas-config.yaml" ]; then
+    migrate_to_pas_dir
+    PAS_CONFIG="$CWD/$PAS_ROOT/config.yaml"
+    if [ -f "$PAS_CONFIG" ]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# Check that feedback is enabled in config.yaml.
 # Returns 1 if feedback is not enabled.
 guard_feedback_enabled() {
   guard_pas_project || return 1
@@ -45,7 +79,7 @@ guard_active_workspace() {
   local script_dir="$1"
   source "$script_dir/lib/workspace.sh"
 
-  WORKSPACE_DIR="$CWD/workspace"
+  WORKSPACE_DIR="$CWD/$PAS_ROOT/workspace"
   if [ ! -d "$WORKSPACE_DIR" ]; then
     return 1
   fi

--- a/plugins/pas/hooks/pas-session-start.sh
+++ b/plugins/pas/hooks/pas-session-start.sh
@@ -67,7 +67,7 @@ ${SESSION_CONTEXT}
 When running a PAS process, you MUST follow this lifecycle:
 
 STARTUP (before any work):
-1. Create workspace: mkdir -p workspace/{process}/{slug}/{discovery,planning,execution/changes,validation,feedback}
+1. Create workspace: mkdir -p .pas/workspace/{process}/{slug}/{discovery,planning,execution/changes,validation,feedback}
 2. Write status.yaml with all phases as pending
 3. Create Claude Code tasks for each phase AND for shutdown steps:
    - One task per phase from process.md
@@ -76,7 +76,7 @@ STARTUP (before any work):
    - Task: "[PAS] Finalize status" — set status.yaml to completed with completed_at timestamp
 
 SHUTDOWN (after all phases complete):
-1. Write self-evaluation to workspace/{process}/{slug}/feedback/orchestrator-${SESSION_SHORT:-SESSION_ID}.md
+1. Write self-evaluation to .pas/workspace/{process}/{slug}/feedback/orchestrator-${SESSION_SHORT:-SESSION_ID}.md
 2. Route any framework:pas signals as GitHub issues
 3. Update status.yaml: set status to completed with completed_at timestamp
 4. Mark all shutdown tasks as completed

--- a/plugins/pas/hooks/route-feedback.sh
+++ b/plugins/pas/hooks/route-feedback.sh
@@ -23,18 +23,18 @@ resolve_target_path() {
 
   case "$type" in
     process)
-      echo "$CWD/processes/$value/feedback/backlog"
+      echo "$CWD/$PAS_ROOT/processes/$value/feedback/backlog"
       ;;
     agent)
       local found
-      found=$(find "$CWD/processes" -path "*/agents/$value/feedback/backlog" -type d 2>/dev/null | head -1)
+      found=$(find "$CWD/$PAS_ROOT/processes" -path "*/agents/$value/feedback/backlog" -type d 2>/dev/null | head -1)
       echo "${found:-}"
       ;;
     skill)
       local found
-      found=$(find "$CWD/processes" -path "*/skills/$value/feedback/backlog" -type d 2>/dev/null | head -1)
+      found=$(find "$CWD/$PAS_ROOT/processes" -path "*/skills/$value/feedback/backlog" -type d 2>/dev/null | head -1)
       if [ -z "$found" ]; then
-        found=$(find "$CWD/library" -path "*/$value/feedback/backlog" -type d 2>/dev/null | head -1)
+        found=$(find "$CWD/$PAS_ROOT/library" -path "*/$value/feedback/backlog" -type d 2>/dev/null | head -1)
       fi
       echo "${found:-}"
       ;;
@@ -65,7 +65,7 @@ route_signal() {
 route_framework_signal() {
   local signal_block="$1"
   local signal_id="$2"
-  local log_dir="$CWD/feedback"
+  local log_dir="$CWD/$PAS_ROOT/feedback"
   mkdir -p "$log_dir"
 
   # Guard: only route signals marked for GitHub issue creation
@@ -124,8 +124,8 @@ parse_and_route_signals() {
         elif [ -n "$target_path" ]; then
           route_signal "$current_signal" "$current_id" "$source_name" "$target_path"
         else
-          mkdir -p "$CWD/feedback"
-          echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$CWD/feedback/warnings.log" 2>/dev/null || true
+          mkdir -p "$CWD/$PAS_ROOT/feedback"
+          echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$CWD/$PAS_ROOT/feedback/warnings.log" 2>/dev/null || true
         fi
       fi
 
@@ -152,8 +152,8 @@ $line"
     elif [ -n "$target_path" ]; then
       route_signal "$current_signal" "$current_id" "$source_name" "$target_path"
     else
-      mkdir -p "$CWD/feedback"
-      echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$CWD/feedback/warnings.log" 2>/dev/null || true
+      mkdir -p "$CWD/$PAS_ROOT/feedback"
+      echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$CWD/$PAS_ROOT/feedback/warnings.log" 2>/dev/null || true
     fi
   fi
 }

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -102,20 +102,47 @@ assert_file_contains() {
   fi
 }
 
+assert_dir_exists() {
+  local dir="$1"
+  local test_name="$2"
+  if [ -d "$dir" ]; then
+    PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${RESET} %s\n" "$test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$test_name: dir not found: $dir")
+    printf "  ${RED}FAIL${RESET} %s (dir not found)\n" "$test_name"
+  fi
+}
+
+assert_dir_not_exists() {
+  local dir="$1"
+  local test_name="$2"
+  if [ ! -d "$dir" ]; then
+    PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${RESET} %s\n" "$test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$test_name: dir should not exist: $dir")
+    printf "  ${RED}FAIL${RESET} %s (dir should not exist)\n" "$test_name"
+  fi
+}
+
 # --- Setup test environment ---
 
 TESTDIR=$(mktemp -d)
 trap 'rm -rf "$TESTDIR" /tmp/test-hook-stdout /tmp/test-hook-stderr' EXIT
 
-# Create PAS config
-cat > "$TESTDIR/pas-config.yaml" <<'EOF'
+# Create PAS config under .pas/
+mkdir -p "$TESTDIR/.pas"
+cat > "$TESTDIR/.pas/config.yaml" <<'EOF'
 feedback: enabled
 feedback_disabled_at: ~
 EOF
 
 # Create workspace with in_progress status
-mkdir -p "$TESTDIR/workspace/test/cycle-1/feedback"
-cat > "$TESTDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+mkdir -p "$TESTDIR/.pas/workspace/test/cycle-1/feedback"
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<'EOF'
 process: test
 instance: cycle-1
 started_at: 2026-03-10T10:00:00+00:00
@@ -142,23 +169,23 @@ trap 'rm -rf "$TESTDIR" "$NOPADIR" /tmp/test-hook-stdout /tmp/test-hook-stderr' 
 
 run_hook "pas-session-start.sh" \
   "{\"cwd\":\"$NOPADIR\",\"source\":\"startup\",\"session_id\":\"test1234abcd\"}" \
-  0 "session-start: no pas-config.yaml"
+  0 "session-start: no .pas/config.yaml"
 
 run_hook "verify-completion-gate.sh" \
   "{\"cwd\":\"$NOPADIR\",\"stop_hook_active\":false,\"session_id\":\"test1234abcd\"}" \
-  0 "completion-gate: no pas-config.yaml"
+  0 "completion-gate: no .pas/config.yaml"
 
 run_hook "verify-task-completion.sh" \
   "{\"cwd\":\"$NOPADIR\",\"task_subject\":\"[PAS] Self-evaluation\"}" \
-  0 "task-completion: no pas-config.yaml"
+  0 "task-completion: no .pas/config.yaml"
 
 run_hook "check-self-eval.sh" \
   "{\"cwd\":\"$NOPADIR\",\"agent_id\":\"test-agent\"}" \
-  0 "check-self-eval: no pas-config.yaml"
+  0 "check-self-eval: no .pas/config.yaml"
 
 run_hook "route-feedback.sh" \
   "{\"cwd\":\"$NOPADIR\"}" \
-  0 "route-feedback: no pas-config.yaml"
+  0 "route-feedback: no .pas/config.yaml"
 
 # =========================================================================
 # Section 2: workspace.sh — in_progress preference (C1 regression)
@@ -167,8 +194,8 @@ run_hook "route-feedback.sh" \
 printf "\n${BOLD}2. Workspace resolution — in_progress preference (C1)${RESET}\n"
 
 # Create a second workspace that is completed (more recent mtime)
-mkdir -p "$TESTDIR/workspace/test/cycle-0/feedback"
-cat > "$TESTDIR/workspace/test/cycle-0/status.yaml" <<'EOF'
+mkdir -p "$TESTDIR/.pas/workspace/test/cycle-0/feedback"
+cat > "$TESTDIR/.pas/workspace/test/cycle-0/status.yaml" <<'EOF'
 process: test
 instance: cycle-0
 started_at: 2026-03-09T10:00:00+00:00
@@ -177,10 +204,10 @@ status: completed
 EOF
 # Touch completed workspace to make it more recent
 sleep 0.1
-touch "$TESTDIR/workspace/test/cycle-0/status.yaml"
+touch "$TESTDIR/.pas/workspace/test/cycle-0/status.yaml"
 
 # Source workspace.sh and test
-RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$TESTDIR/workspace'")
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$TESTDIR/.pas/workspace'")
 if echo "$RESULT" | grep -q "cycle-1/status.yaml"; then
   PASS=$((PASS + 1))
   printf "  ${GREEN}PASS${RESET} workspace resolution prefers in_progress over completed\n"
@@ -191,14 +218,14 @@ else
 fi
 
 # Test fallback: when no in_progress workspace exists, fall back to most recent
-mkdir -p "$TESTDIR/workspace-fallback/old/feedback"
-cat > "$TESTDIR/workspace-fallback/old/status.yaml" <<'EOF'
+mkdir -p "$TESTDIR/.pas/workspace-fallback/old/feedback"
+cat > "$TESTDIR/.pas/workspace-fallback/old/status.yaml" <<'EOF'
 process: test
 instance: old
 status: completed
 EOF
 
-RESULT2=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$TESTDIR/workspace-fallback'")
+RESULT2=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$TESTDIR/.pas/workspace-fallback'")
 if echo "$RESULT2" | grep -q "old/status.yaml"; then
   PASS=$((PASS + 1))
   printf "  ${GREEN}PASS${RESET} workspace resolution falls back to completed when no in_progress\n"
@@ -222,10 +249,10 @@ assert_stdout_contains "Session ID: abc12345" "session-start: outputs session ID
 assert_stdout_contains "PAS Framework Active" "session-start: outputs framework status"
 assert_stdout_contains "feedback: enabled" "session-start: outputs feedback status"
 
-assert_file_contains "$TESTDIR/workspace/test/cycle-1/status.yaml" \
+assert_file_contains "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" \
   "current_session: abc12345" "session-start: writes current_session to status.yaml"
 
-assert_file_contains "$TESTDIR/workspace/test/cycle-1/status.yaml" \
+assert_file_contains "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" \
   "id: abc12345" "session-start: appends session to sessions list"
 
 # =========================================================================
@@ -240,7 +267,7 @@ run_hook "verify-completion-gate.sh" \
   0 "completion-gate: pending phases → exit 0"
 
 # 4b: All completed, no feedback → exit 2
-cat > "$TESTDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<'EOF'
 process: test
 instance: cycle-1
 status: in_progress
@@ -261,15 +288,15 @@ assert_stderr_contains "COMPLETION GATE FAILED" "completion-gate: stderr shows g
 assert_stderr_contains "orchestrator-abc12345.md" "completion-gate: stderr names expected file"
 
 # 4c: Session-specific feedback exists → exit 0
-echo "No issues detected." > "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
+echo "No issues detected." > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
 
 run_hook "verify-completion-gate.sh" \
   "{\"cwd\":\"$TESTDIR\",\"stop_hook_active\":false,\"session_id\":\"abc12345xyz\"}" \
   0 "completion-gate: session feedback exists → exit 0"
 
 # 4d: Feedback from DIFFERENT session → exit 2
-rm "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
-echo "No issues detected." > "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-previous.md"
+rm "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
+echo "No issues detected." > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-previous.md"
 
 run_hook "verify-completion-gate.sh" \
   "{\"cwd\":\"$TESTDIR\",\"stop_hook_active\":false,\"session_id\":\"abc12345xyz\"}" \
@@ -281,7 +308,7 @@ run_hook "verify-completion-gate.sh" \
   0 "completion-gate: stop_hook_active → exit 0 (loop prevention)"
 
 # 4f: Completed workspace → exit 0 (C2 regression — Issue #23)
-cat > "$TESTDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<'EOF'
 process: test
 instance: cycle-1
 status: completed
@@ -299,7 +326,7 @@ run_hook "verify-completion-gate.sh" \
   0 "completion-gate: completed workspace → exit 0 (Issue #23 regression)"
 
 # 4g: Agent feedback enforcement (Issue #19 regression)
-cat > "$TESTDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<'EOF'
 process: test
 instance: cycle-1
 status: in_progress
@@ -315,7 +342,7 @@ phases:
 EOF
 
 # Orchestrator feedback exists, but agent feedback missing → exit 2
-echo "No issues detected." > "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
+echo "No issues detected." > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
 
 run_hook "verify-completion-gate.sh" \
   "{\"cwd\":\"$TESTDIR\",\"stop_hook_active\":false,\"session_id\":\"abc12345xyz\"}" \
@@ -325,17 +352,17 @@ assert_stderr_contains "Agent self-evaluation missing" \
   "completion-gate: stderr names missing agents (Issue #19)"
 
 # Add agent feedback → exit 0
-echo "No issues detected." > "$TESTDIR/workspace/test/cycle-1/feedback/framework-architect.md"
-echo "No issues detected." > "$TESTDIR/workspace/test/cycle-1/feedback/dx-specialist.md"
+echo "No issues detected." > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/framework-architect.md"
+echo "No issues detected." > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/dx-specialist.md"
 
 run_hook "verify-completion-gate.sh" \
   "{\"cwd\":\"$TESTDIR\",\"stop_hook_active\":false,\"session_id\":\"abc12345xyz\"}" \
   0 "completion-gate: all agent feedback present → exit 0 (Issue #19)"
 
 # Clean up agent feedback files
-rm -f "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
-rm -f "$TESTDIR/workspace/test/cycle-1/feedback/framework-architect.md"
-rm -f "$TESTDIR/workspace/test/cycle-1/feedback/dx-specialist.md"
+rm -f "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
+rm -f "$TESTDIR/.pas/workspace/test/cycle-1/feedback/framework-architect.md"
+rm -f "$TESTDIR/.pas/workspace/test/cycle-1/feedback/dx-specialist.md"
 
 # =========================================================================
 # Section 5: verify-task-completion.sh
@@ -344,7 +371,7 @@ rm -f "$TESTDIR/workspace/test/cycle-1/feedback/dx-specialist.md"
 printf "\n${BOLD}5. verify-task-completion.sh${RESET}\n"
 
 # Restore in_progress status for task tests
-cat > "$TESTDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<'EOF'
 process: test
 instance: cycle-1
 status: in_progress
@@ -356,7 +383,7 @@ phases:
   planning:
     status: completed
 EOF
-rm -f "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-previous.md"
+rm -f "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-previous.md"
 
 # 5a: Self-eval task without feedback → exit 2
 run_hook "verify-task-completion.sh" \
@@ -366,7 +393,7 @@ run_hook "verify-task-completion.sh" \
 assert_stderr_contains "Cannot complete" "task-completion: stderr shows blocker message"
 
 # 5b: Self-eval task with feedback → exit 0
-echo "No issues detected." > "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
+echo "No issues detected." > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md"
 
 run_hook "verify-task-completion.sh" \
   "{\"cwd\":\"$TESTDIR\",\"task_subject\":\"[PAS] Self-evaluation\"}" \
@@ -378,7 +405,7 @@ run_hook "verify-task-completion.sh" \
   2 "task-completion: finalize without completed status → exit 2"
 
 # 5d: Finalize task with completed status → exit 0
-cat > "$TESTDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<'EOF'
 process: test
 instance: cycle-1
 status: completed
@@ -408,7 +435,7 @@ run_hook "verify-task-completion.sh" \
 printf "\n${BOLD}6. check-self-eval.sh${RESET}\n"
 
 # Restore in_progress status
-cat > "$TESTDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<'EOF'
 process: test
 instance: cycle-1
 status: in_progress
@@ -419,14 +446,14 @@ phases:
 EOF
 
 # 6a: Agent with feedback file → exit 0
-echo "No issues detected." > "$TESTDIR/workspace/test/cycle-1/feedback/test-agent.md"
+echo "No issues detected." > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/test-agent.md"
 
 run_hook "check-self-eval.sh" \
   "{\"cwd\":\"$TESTDIR\",\"agent_id\":\"test-agent\"}" \
   0 "check-self-eval: agent feedback exists → exit 0"
 
 # 6b: Agent without feedback → exit 2
-rm "$TESTDIR/workspace/test/cycle-1/feedback/test-agent.md"
+rm "$TESTDIR/.pas/workspace/test/cycle-1/feedback/test-agent.md"
 
 run_hook "check-self-eval.sh" \
   "{\"cwd\":\"$TESTDIR\",\"agent_id\":\"test-agent\"}" \
@@ -435,7 +462,7 @@ run_hook "check-self-eval.sh" \
 assert_stderr_contains "SELF-EVALUATION MISSING" "check-self-eval: stderr shows missing message"
 
 # 6c: Feedback disabled → exit 0
-cat > "$TESTDIR/pas-config.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/config.yaml" <<'EOF'
 feedback: disabled
 EOF
 
@@ -444,7 +471,7 @@ run_hook "check-self-eval.sh" \
   0 "check-self-eval: feedback disabled → exit 0"
 
 # Restore feedback enabled
-cat > "$TESTDIR/pas-config.yaml" <<'EOF'
+cat > "$TESTDIR/.pas/config.yaml" <<'EOF'
 feedback: enabled
 feedback_disabled_at: ~
 EOF
@@ -456,10 +483,10 @@ EOF
 printf "\n${BOLD}7. route-feedback.sh${RESET}\n"
 
 # 7a: Route signals from feedback file, preserve file, mark as routed
-rm -f "$TESTDIR/workspace/test/cycle-1/feedback/"*.md
-rm -f "$TESTDIR/workspace/test/cycle-1/feedback/"*.routed
+rm -f "$TESTDIR/.pas/workspace/test/cycle-1/feedback/"*.md
+rm -f "$TESTDIR/.pas/workspace/test/cycle-1/feedback/"*.routed
 
-cat > "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md" <<'EOF'
+cat > "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md" <<'EOF'
 [OQI-01]
 Target: process:test
 Degraded: Test signal for routing
@@ -467,26 +494,26 @@ Priority: LOW
 EOF
 
 # Create the process feedback dir for routing target
-mkdir -p "$TESTDIR/processes/test/feedback/backlog"
+mkdir -p "$TESTDIR/.pas/processes/test/feedback/backlog"
 
 run_hook "route-feedback.sh" \
   "{\"cwd\":\"$TESTDIR\"}" \
   0 "route-feedback: routes signals → exit 0"
 
-assert_file_exists "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md" \
+assert_file_exists "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md" \
   "route-feedback: feedback file preserved (not deleted)"
 
-assert_file_exists "$TESTDIR/workspace/test/cycle-1/feedback/orchestrator-abc12345.md.routed" \
+assert_file_exists "$TESTDIR/.pas/workspace/test/cycle-1/feedback/orchestrator-abc12345.md.routed" \
   "route-feedback: .routed marker created"
 
 # 7b: Second run skips already-routed files
-BEFORE_COUNT=$(find "$TESTDIR/processes/test/feedback/backlog" -name "*.md" 2>/dev/null | wc -l)
+BEFORE_COUNT=$(find "$TESTDIR/.pas/processes/test/feedback/backlog" -name "*.md" 2>/dev/null | wc -l)
 
 run_hook "route-feedback.sh" \
   "{\"cwd\":\"$TESTDIR\"}" \
   0 "route-feedback: second run exits 0"
 
-AFTER_COUNT=$(find "$TESTDIR/processes/test/feedback/backlog" -name "*.md" 2>/dev/null | wc -l)
+AFTER_COUNT=$(find "$TESTDIR/.pas/processes/test/feedback/backlog" -name "*.md" 2>/dev/null | wc -l)
 if [ "$BEFORE_COUNT" -eq "$AFTER_COUNT" ]; then
   PASS=$((PASS + 1))
   printf "  ${GREEN}PASS${RESET} route-feedback: no duplicate routing on second run\n"
@@ -500,12 +527,12 @@ fi
 # Section 8: pas-create-process script (C3, C4 regression)
 # =========================================================================
 
-printf "\n${BOLD}8. pas-create-process — lifecycle ref + --force safety${RESET}\n"
+printf "\n${BOLD}8. pas-create-process — .pas/ paths + --force safety${RESET}\n"
 
 CREATE_SCRIPT="$HOOKS_DIR/../processes/pas/agents/orchestrator/skills/creating-processes/scripts/pas-create-process"
 GEN_DIR=$(mktemp -d)
 
-# 8a: Generated process includes lifecycle section
+# 8a: Generated process lives under .pas/processes/
 bash "$CREATE_SCRIPT" \
   --name test-proc \
   --goal "Test process" \
@@ -514,28 +541,44 @@ bash "$CREATE_SCRIPT" \
   --input "data:Test input" \
   --base-dir "$GEN_DIR" 2>/dev/null
 
-if grep -q "library/orchestration/lifecycle.md" "$GEN_DIR/processes/test-proc/process.md"; then
-  PASS=$((PASS + 1))
-  printf "  ${GREEN}PASS${RESET} pas-create-process: process.md references lifecycle.md (C3)\n"
-else
-  FAIL=$((FAIL + 1))
-  ERRORS+=("process.md missing lifecycle.md reference")
-  printf "  ${RED}FAIL${RESET} pas-create-process: process.md missing lifecycle.md reference\n"
-fi
+assert_dir_exists "$GEN_DIR/.pas/processes/test-proc" \
+  "pas-create-process: process created under .pas/processes/"
 
-# 8b: Generated thin launcher includes lifecycle reference
-if grep -q "lifecycle.md" "$GEN_DIR/.claude/skills/test-proc/SKILL.md"; then
-  PASS=$((PASS + 1))
-  printf "  ${GREEN}PASS${RESET} pas-create-process: thin launcher references lifecycle.md (C3)\n"
-else
-  FAIL=$((FAIL + 1))
-  ERRORS+=("thin launcher missing lifecycle.md reference")
-  printf "  ${RED}FAIL${RESET} pas-create-process: thin launcher missing lifecycle.md reference\n"
-fi
+assert_file_exists "$GEN_DIR/.pas/processes/test-proc/process.md" \
+  "pas-create-process: process.md exists"
 
-# 8c: --force preserves reference/ directory (C4)
-mkdir -p "$GEN_DIR/processes/test-proc/reference/source"
-echo "precious data" > "$GEN_DIR/processes/test-proc/reference/source/material.txt"
+# 8b: process.md references .pas/ paths
+assert_file_contains "$GEN_DIR/.pas/processes/test-proc/process.md" \
+  ".pas/library/orchestration/lifecycle.md" \
+  "pas-create-process: process.md references .pas/library/lifecycle.md"
+
+assert_file_contains "$GEN_DIR/.pas/processes/test-proc/process.md" \
+  "status_file: .pas/workspace/test-proc/" \
+  "pas-create-process: status_file uses .pas/workspace/"
+
+# 8c: Thin launcher in .claude/skills/ references .pas/ paths
+assert_file_exists "$GEN_DIR/.claude/skills/test-proc/SKILL.md" \
+  "pas-create-process: thin launcher in .claude/skills/"
+
+assert_file_contains "$GEN_DIR/.claude/skills/test-proc/SKILL.md" \
+  ".pas/processes/test-proc/process.md" \
+  "pas-create-process: thin launcher references .pas/processes/"
+
+assert_file_contains "$GEN_DIR/.claude/skills/test-proc/SKILL.md" \
+  ".pas/library/orchestration/lifecycle.md" \
+  "pas-create-process: thin launcher references .pas/library/"
+
+# 8d: No artifacts at project root
+assert_dir_not_exists "$GEN_DIR/processes" \
+  "pas-create-process: no processes/ at project root"
+
+# 8e: feedback/backlog exists
+assert_dir_exists "$GEN_DIR/.pas/processes/test-proc/feedback/backlog" \
+  "pas-create-process: feedback/backlog exists"
+
+# 8f: --force preserves reference/ directory (C4)
+mkdir -p "$GEN_DIR/.pas/processes/test-proc/reference/source"
+echo "precious data" > "$GEN_DIR/.pas/processes/test-proc/reference/source/material.txt"
 
 bash "$CREATE_SCRIPT" \
   --name test-proc \
@@ -546,8 +589,8 @@ bash "$CREATE_SCRIPT" \
   --base-dir "$GEN_DIR" \
   --force 2>/dev/null
 
-if [ -f "$GEN_DIR/processes/test-proc/reference/source/material.txt" ]; then
-  CONTENT=$(cat "$GEN_DIR/processes/test-proc/reference/source/material.txt")
+if [ -f "$GEN_DIR/.pas/processes/test-proc/reference/source/material.txt" ]; then
+  CONTENT=$(cat "$GEN_DIR/.pas/processes/test-proc/reference/source/material.txt")
   if [ "$CONTENT" = "precious data" ]; then
     PASS=$((PASS + 1))
     printf "  ${GREEN}PASS${RESET} pas-create-process: --force preserves reference/ (C4)\n"
@@ -577,10 +620,11 @@ run_hook "pas-session-start.sh" \
 
 # 9b: Empty workspace directory — no status.yaml found
 EMPTYDIR=$(mktemp -d)
-cat > "$EMPTYDIR/pas-config.yaml" <<'EOF'
+mkdir -p "$EMPTYDIR/.pas"
+cat > "$EMPTYDIR/.pas/config.yaml" <<'EOF'
 feedback: enabled
 EOF
-mkdir -p "$EMPTYDIR/workspace"
+mkdir -p "$EMPTYDIR/.pas/workspace"
 
 run_hook "verify-completion-gate.sh" \
   "{\"cwd\":\"$EMPTYDIR\",\"stop_hook_active\":false,\"session_id\":\"test1234\"}" \
@@ -590,7 +634,8 @@ rm -rf "$EMPTYDIR"
 
 # 9c: No workspace directory at all
 NOWSDIR=$(mktemp -d)
-cat > "$NOWSDIR/pas-config.yaml" <<'EOF'
+mkdir -p "$NOWSDIR/.pas"
+cat > "$NOWSDIR/.pas/config.yaml" <<'EOF'
 feedback: enabled
 EOF
 
@@ -599,6 +644,71 @@ run_hook "verify-completion-gate.sh" \
   0 "edge-case: no workspace dir → exit 0"
 
 rm -rf "$NOWSDIR"
+
+# =========================================================================
+# Section 10: Migration — old-style layout auto-migrates
+# =========================================================================
+
+printf "\n${BOLD}10. Migration — old-style layout auto-migrates${RESET}\n"
+
+MIGDIR=$(mktemp -d)
+
+# Set up old-style layout at root
+cat > "$MIGDIR/pas-config.yaml" <<'EOF'
+feedback: enabled
+feedback_disabled_at: ~
+EOF
+mkdir -p "$MIGDIR/workspace/test/cycle-1/feedback"
+cat > "$MIGDIR/workspace/test/cycle-1/status.yaml" <<'EOF'
+process: test
+instance: cycle-1
+status: in_progress
+
+phases:
+  work:
+    status: completed
+EOF
+mkdir -p "$MIGDIR/processes/test/feedback/backlog"
+mkdir -p "$MIGDIR/library/orchestration"
+
+# Run session-start hook — should trigger migration
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$MIGDIR\",\"source\":\"startup\",\"session_id\":\"mig12345xyz\"}" \
+  0 "migration: session-start triggers migration → exit 0"
+
+# Verify migration happened
+assert_file_exists "$MIGDIR/.pas/config.yaml" \
+  "migration: .pas/config.yaml exists after migration"
+
+assert_dir_exists "$MIGDIR/.pas/workspace" \
+  "migration: .pas/workspace/ exists after migration"
+
+assert_dir_exists "$MIGDIR/.pas/processes" \
+  "migration: .pas/processes/ exists after migration"
+
+assert_dir_exists "$MIGDIR/.pas/library" \
+  "migration: .pas/library/ exists after migration"
+
+# Old paths should be gone
+if [ ! -f "$MIGDIR/pas-config.yaml" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} migration: old pas-config.yaml removed\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("migration: old pas-config.yaml still exists")
+  printf "  ${RED}FAIL${RESET} migration: old pas-config.yaml still exists\n"
+fi
+
+if [ ! -d "$MIGDIR/workspace" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} migration: old workspace/ removed\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("migration: old workspace/ still exists")
+  printf "  ${RED}FAIL${RESET} migration: old workspace/ still exists\n"
+fi
+
+rm -rf "$MIGDIR"
 
 # =========================================================================
 # Summary

--- a/plugins/pas/hooks/verify-completion-gate.sh
+++ b/plugins/pas/hooks/verify-completion-gate.sh
@@ -94,7 +94,7 @@ fi
   echo ""
   echo "Before stopping, you MUST:"
   echo "1. Write self-evaluation to ${FEEDBACK_DIR}/${EXPECTED_FILE}"
-  echo "   - Use library/self-evaluation/SKILL.md for the format"
+  echo "   - Use .pas/library/self-evaluation/SKILL.md for the format"
   echo "   - If nothing went wrong, write \"No issues detected.\""
   if [ -n "$MISSING_AGENTS" ]; then
     echo "2. Ensure all agents have written their feedback files"

--- a/plugins/pas/hooks/verify-task-completion.sh
+++ b/plugins/pas/hooks/verify-task-completion.sh
@@ -43,7 +43,7 @@ case "$TASK_SUBJECT" in
 Cannot complete "Self-evaluation" task: ${FEEDBACK_DIR}/${EXPECTED} does not exist.
 
 Write your self-evaluation to this file before marking the task complete.
-Use library/self-evaluation/SKILL.md for the format.
+Use .pas/library/self-evaluation/SKILL.md for the format.
 EOF
       exit 2
     fi

--- a/plugins/pas/library/message-routing/SKILL.md
+++ b/plugins/pas/library/message-routing/SKILL.md
@@ -27,7 +27,7 @@ Classify user messages at gates to determine the correct response. Used by orche
 
 **Behavior:**
 1. **Fix in session**: route the feedback to the appropriate agent to revise the output. Re-present the gate after revision.
-2. **Queue for permanent improvement**: if feedback is enabled, write a structured signal to the workspace feedback inbox (`workspace/{process}/{slug}/feedback/`). Use the self-evaluation signal format:
+2. **Queue for permanent improvement**: if feedback is enabled, write a structured signal to the workspace feedback inbox (`.pas/workspace/{process}/{slug}/feedback/`). Use the self-evaluation signal format:
    - PPU if the feedback expresses a persistent preference
    - OQI if the feedback identifies an output quality issue
    - Include `Target:` pointing to the skill or agent that produced the output

--- a/plugins/pas/library/orchestration/hub-and-spoke.md
+++ b/plugins/pas/library/orchestration/hub-and-spoke.md
@@ -14,7 +14,7 @@ The default pattern for multi-agent processes. A central orchestrator reads the 
 3. **Create workspace** -- follow `lifecycle.md` > Workspace Creation
 4. **Create lifecycle tasks** -- follow `lifecycle.md` > Lifecycle Task Creation
 5. **Load orchestration skills**: read this file for execution rules
-6. **When feedback is enabled**: carry `library/self-evaluation/SKILL.md` for shutdown
+6. **When feedback is enabled**: carry `.pas/library/self-evaluation/SKILL.md` for shutdown
 7. **Spawn team members** via TeamCreate for all specialist agents defined in process.md. Follow `lifecycle.md` > Ready Handshake -- wait for all agents to confirm READY before dispatching work.
 
 ## Spawning Team Members
@@ -22,11 +22,11 @@ The default pattern for multi-agent processes. A central orchestrator reads the 
 Use TeamCreate for each specialist agent. The spawn prompt tells them:
 
 - Their role: "You are the {name}"
-- Where to find their definition: "Read your agent.md at `processes/{process}/agents/{name}/agent.md`"
+- Where to find their definition: "Read your agent.md at `.pas/processes/{process}/agents/{name}/agent.md`"
 - Where to find their skills: "Read your skills from the `skills/` directory listed in your agent.md"
-- Where to write output: "Write output to `workspace/{process}/{slug}/{output-folder}/`"
+- Where to write output: "Write output to `.pas/workspace/{process}/{slug}/{output-folder}/`"
 - Feedback status: whether self-evaluation is active
-- Self-evaluation instructions: "Before returning your final result, if feedback is enabled in `pas-config.yaml`, read `library/self-evaluation/SKILL.md` and write feedback to `workspace/{process}/{slug}/feedback/{your-name}.md`"
+- Self-evaluation instructions: "Before returning your final result, if feedback is enabled in `.pas/config.yaml`, read `.pas/library/self-evaluation/SKILL.md` and write feedback to `.pas/workspace/{process}/{slug}/feedback/{your-name}.md`"
 - Ready handshake: "After reading your agent.md and skills, send a message to the orchestrator containing only: `READY: {agent-name}`"
 
 Team members persist for the full process lifecycle. They retain work context for richer self-evaluation and can receive downstream feedback from later phases. Idle agents cost zero tokens.
@@ -83,9 +83,9 @@ Every subagent spawn prompt MUST include:
 
 1. **Verified file paths**: Before dispatching, confirm all referenced paths exist. Do not propagate paths without verification -- a wrong path in the spawn prompt will be replicated across all subagent work.
 2. **Specific scope**: One clear objective per agent. "Fix link-building skill" not "fix all skills."
-3. **Output location**: Exact path for writing results to `workspace/{process}/{slug}/`
+3. **Output location**: Exact path for writing results to `.pas/workspace/{process}/{slug}/`
 4. **Shutdown protocol**: "When your task is complete: 1) Write your self-evaluation, 2) Return your summary. Do not shut down before completing self-evaluation."
-5. **Self-evaluation instructions** (when feedback enabled): "Before returning your final result, read `library/self-evaluation/SKILL.md` and write feedback to `workspace/{process}/{slug}/feedback/{your-name}.md`"
+5. **Self-evaluation instructions** (when feedback enabled): "Before returning your final result, read `.pas/library/self-evaluation/SKILL.md` and write feedback to `.pas/workspace/{process}/{slug}/feedback/{your-name}.md`"
 
 ### Feedback Rules
 
@@ -128,7 +128,7 @@ Gates are checkpoints where the process pauses for review. Behavior depends on t
 1. Phase completes, orchestrator presents output summary (not raw files unless asked)
 2. Flag any quality concerns or red flags
 3. Ask: "Approve and continue, or request changes?"
-4. Classify the user's response using `library/message-routing/SKILL.md`:
+4. Classify the user's response using `.pas/library/message-routing/SKILL.md`:
    - Approval: proceed to next phase
    - Feedback: fix in session + queue signal for permanent improvement
    - Question: answer, then re-present gate

--- a/plugins/pas/library/orchestration/lifecycle.md
+++ b/plugins/pas/library/orchestration/lifecycle.md
@@ -12,14 +12,14 @@ Every orchestration pattern shares this lifecycle protocol. Pattern-specific fil
 This is a **HARD REQUIREMENT**, not optional. Do NOT proceed to any subsequent startup step until the workspace directory and status.yaml exist on disk.
 
 ```bash
-mkdir -p workspace/{process}/{slug}/discovery
-mkdir -p workspace/{process}/{slug}/planning
-mkdir -p workspace/{process}/{slug}/execution/changes
-mkdir -p workspace/{process}/{slug}/validation
-mkdir -p workspace/{process}/{slug}/feedback
+mkdir -p .pas/workspace/{process}/{slug}/discovery
+mkdir -p .pas/workspace/{process}/{slug}/planning
+mkdir -p .pas/workspace/{process}/{slug}/execution/changes
+mkdir -p .pas/workspace/{process}/{slug}/validation
+mkdir -p .pas/workspace/{process}/{slug}/feedback
 ```
 
-Write `workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
+Write `.pas/workspace/{process}/{slug}/status.yaml` with all phases as `pending`, `started_at` timestamp, and `status: in_progress`.
 
 **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase (see Resumability below). Do not re-create the workspace.
 
@@ -31,7 +31,7 @@ For each phase in process.md:
 - `[PAS] Phase: {phase-name}` -- description: "{agent} processes {input} to produce {output}"
 
 Shutdown tasks (always created):
-- `[PAS] Self-evaluation` -- description: "Write feedback/orchestrator.md using library/self-evaluation/SKILL.md"
+- `[PAS] Self-evaluation` -- description: "Write feedback/orchestrator.md using .pas/library/self-evaluation/SKILL.md"
 - `[PAS] Route framework signals` -- description: "File any framework:pas signals as GitHub issues"
 - `[PAS] Finalize status` -- description: "Set status.yaml status to completed with completed_at timestamp"
 
@@ -56,7 +56,7 @@ The solo pattern does not use this protocol since it does not spawn agents.
 
 ## Status Tracking
 
-Write `workspace/{process}/{slug}/status.yaml` continuously at every state change. Status is a performance log, not just state.
+Write `.pas/workspace/{process}/{slug}/status.yaml` continuously at every state change. Status is a performance log, not just state.
 
 **Valid states:** `pending`, `in_progress`, `completed`. Add process-specific states only when the user requests them.
 
@@ -100,9 +100,9 @@ When all phases are complete:
 
 1. **Verify all output files** exist for all phases
 2. **Send downstream feedback** to each team member (if any): share relevant quality notes from later phases
-3. **Each agent writes self-evaluation** using `library/self-evaluation/SKILL.md` (when feedback is enabled). This is mandatory -- do NOT proceed to step 4 until all agents have written their feedback. Output to `workspace/{process}/{slug}/feedback/{agent-name}.md`. The `check-self-eval.sh` SubagentStop hook blocks agents from stopping without feedback, and the `verify-completion-gate.sh` Stop hook verifies ALL agents have feedback files before the orchestrator can stop.
+3. **Each agent writes self-evaluation** using `.pas/library/self-evaluation/SKILL.md` (when feedback is enabled). This is mandatory -- do NOT proceed to step 4 until all agents have written their feedback. Output to `.pas/workspace/{process}/{slug}/feedback/{agent-name}.md`. The `check-self-eval.sh` SubagentStop hook blocks agents from stopping without feedback, and the `verify-completion-gate.sh` Stop hook verifies ALL agents have feedback files before the orchestrator can stop.
 4. **All agents shut down together** after self-evaluation completes. The orchestrator MUST NOT instruct agents to skip self-evaluation — hook enforcement will block the session if any agent feedback is missing.
-5. **Orchestrator writes own self-evaluation** to `workspace/{process}/{slug}/feedback/orchestrator.md`. The orchestrator is an agent too -- it observes issues that team members cannot (coordination failures, gate misjudgments, process-level problems). Do NOT skip this step.
+5. **Orchestrator writes own self-evaluation** to `.pas/workspace/{process}/{slug}/feedback/orchestrator.md`. The orchestrator is an agent too -- it observes issues that team members cannot (coordination failures, gate misjudgments, process-level problems). Do NOT skip this step.
 6. **Route framework signals**: Any signal with target `framework:pas` must be filed as a GitHub issue on the PAS repository. Do not leave framework signals in local feedback files only.
 7. **Verify all feedback signals** have been routed to their destinations (GitHub issues, artifact backlogs, etc.) before declaring session complete
 8. **Orchestrator finalizes status.yaml**: mark process as `completed`, record final timestamps and quality scores
@@ -114,7 +114,7 @@ For solo pattern: steps 2-4 are skipped (no team members). The orchestrator writ
 Before declaring the session complete, ALL of the following MUST be true:
 
 1. All phases have `status: completed` in status.yaml
-2. All feedback files exist in `workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
+2. All feedback files exist in `.pas/workspace/{process}/{slug}/feedback/` (one per agent + orchestrator)
 3. All signals with target `framework:pas` have been filed as GitHub issues
 4. `status.yaml` has `completed_at` timestamp and `status: completed`
 
@@ -130,7 +130,7 @@ After the completion gate is satisfied, **always offer the product owner the opt
 
 If a session is interrupted (context limits, user leaves, crash):
 
-1. On next session start, read `workspace/{process}/{slug}/status.yaml`
+1. On next session start, read `.pas/workspace/{process}/{slug}/status.yaml`
 2. Identify last completed phase and current in_progress phase
 3. For in_progress phases: check if output files exist and are complete
    - If complete but not marked: mark as completed, proceed

--- a/plugins/pas/library/self-evaluation/SKILL.md
+++ b/plugins/pas/library/self-evaluation/SKILL.md
@@ -11,7 +11,7 @@ Write structured improvement signals at shutdown. This skill activates only at s
 
 - You are shutting down after completing your work
 - You have already received any downstream feedback from later phases
-- Feedback is enabled in `pas-config.yaml`
+- Feedback is enabled in `.pas/config.yaml`
 
 Do NOT activate during work. Do NOT evaluate while producing output. Wait until shutdown.
 
@@ -19,7 +19,7 @@ Do NOT activate during work. Do NOT evaluate while producing output. Wait until 
 
 1. Reflect on the session: what went well, what went wrong, what the user corrected
 2. For each observation, determine the signal type (see below)
-3. Write signals to `workspace/{process}/{slug}/feedback/{your-agent-name}-{session_id}.md`
+3. Write signals to `.pas/workspace/{process}/{slug}/feedback/{your-agent-name}-{session_id}.md`
 
    The session ID is provided by the SessionStart hook and recorded in `status.yaml` under `current_session`. If no session ID is available, use your agent name without a suffix.
 4. If nothing went wrong: write "No issues detected." and stop. Do NOT list positives.
@@ -104,7 +104,7 @@ When a signal targets the PAS framework itself (not a specific process, agent, o
 - A library skill needs improvement
 
 **Routing chain:**
-1. Agent writes the signal locally to `workspace/{process}/{slug}/feedback/{agent-name}.md` with `Target: framework:pas`
+1. Agent writes the signal locally to `.pas/workspace/{process}/{slug}/feedback/{agent-name}.md` with `Target: framework:pas`
 2. Agent appends `Route: github-issue` to the signal block
 3. At shutdown, the orchestrator reads all feedback files, finds signals marked `Route: github-issue`, and files them as GitHub issues on the PAS repository
 

--- a/plugins/pas/processes/pas/agents/orchestrator/agent.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/agent.md
@@ -34,8 +34,8 @@ You are the PAS framework assistant. You help users create and manage processes,
 
 ## Deliverables
 
-- Created or modified process definitions (`processes/{name}/process.md`)
-- Created or modified agent definitions (`processes/{name}/agents/{agent}/agent.md`)
+- Created or modified process definitions (`.pas/processes/{name}/process.md`)
+- Created or modified agent definitions (`.pas/processes/{name}/agents/{agent}/agent.md`)
 - Created or modified skills (`SKILL.md` files)
 - Created or modified hooks (`hooks.json`, settings hooks, frontmatter hooks, hook scripts)
 - Applied feedback with changelog entries

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md
@@ -13,10 +13,10 @@ Review and apply accumulated feedback signals from backlogs across all PAS artif
 
 Recursively scan for pending feedback:
 
-- `processes/*/feedback/backlog/` — process-level signals
-- `processes/*/agents/*/feedback/backlog/` — agent-level signals
-- `processes/*/agents/*/skills/*/feedback/backlog/` — skill-level signals
-- `library/*/feedback/backlog/` — library skill signals
+- `.pas/processes/*/feedback/backlog/` — process-level signals
+- `.pas/processes/*/agents/*/feedback/backlog/` — agent-level signals
+- `.pas/processes/*/agents/*/skills/*/feedback/backlog/` — skill-level signals
+- `.pas/library/*/feedback/backlog/` — library skill signals
 
 List all directories containing `.md` files (pending signals).
 

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/SKILL.md
@@ -20,7 +20,7 @@ Define the agent's purpose within the process:
 
 ### 2. Check for Overlap
 
-Before creating a new agent, check existing agents in `processes/{process}/agents/`:
+Before creating a new agent, check existing agents in `.pas/processes/{process}/agents/`:
 
 - Would an existing agent's skills cover this role?
 - Could an existing agent be extended instead of creating a new one?
@@ -33,7 +33,7 @@ For each skill the agent needs:
 - Read `creating-skills/SKILL.md` from the same skills directory as this skill
 - Follow its workflow to create each skill
 - Skills live inside the agent's directory at `skills/{skill-name}/SKILL.md`
-- Check `library/` for global skills the agent should carry (e.g., `library/self-evaluation/SKILL.md`)
+- Check `.pas/library/` for global skills the agent should carry (e.g., `.pas/library/self-evaluation/SKILL.md`)
 
 ### 4. Select Model Tier
 

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/scripts/pas-create-agent
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-agents/scripts/pas-create-agent
@@ -123,7 +123,7 @@ if [[ "$ROLE" == "orchestrator" ]]; then
 fi
 
 # Build target path
-TARGET="${BASE_DIR:+${BASE_DIR}/}processes/${PROCESS}/agents/${NAME}"
+TARGET="${BASE_DIR:+${BASE_DIR}/}.pas/processes/${PROCESS}/agents/${NAME}"
 
 # Check directory conflict
 if [[ -d "$TARGET" && "$FORCE" != true ]]; then
@@ -158,7 +158,7 @@ description: ${DESCRIPTION}
 model: ${MODEL}
 tools: ${TOOLS_YAML}
 skills:
-  - library/self-evaluation/SKILL.md
+  - .pas/library/self-evaluation/SKILL.md
 ---
 
 # ${TITLE}
@@ -179,8 +179,8 @@ EOF
   # Orchestrator-specific behavior
   if [[ "$ROLE" == "orchestrator" ]]; then
     cat <<'EOF'
-- Read processes/{process}/process.md on startup
-- Read the orchestration pattern from library/orchestration/ as declared in process.md
+- Read .pas/processes/{process}/process.md on startup
+- Read the orchestration pattern from .pas/library/orchestration/ as declared in process.md
 - Read workspace status to determine where to resume
 - Delegate phases to specialist agents via TeamCreate
 - Interface with the user at gates (supervised mode)
@@ -206,7 +206,7 @@ EOF
 
 # Fix the orchestrator behavior to use actual process name
 if [[ "$ROLE" == "orchestrator" ]]; then
-  sed -i "s|processes/{process}|processes/${PROCESS}|g" "${TARGET}/agent.md"
+  sed -i "s|.pas/processes/{process}|.pas/processes/${PROCESS}|g" "${TARGET}/agent.md"
 fi
 
 echo "  Created ${TARGET}/agent.md"

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/SKILL.md
@@ -28,7 +28,7 @@ Define what the hook does:
 
 ### 1a. PAS Feedback Hook Setup
 
-If creating hooks for a PAS process and `pas-config.yaml` has `feedback: enabled`:
+If creating hooks for a PAS process and `.pas/config.yaml` has `feedback: enabled`:
 
 - Read `references/pas-feedback-hooks.md`
 - Generate enhanced `check-self-eval.sh` (SubagentStop) and `route-feedback.sh` (Stop)

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/references/pas-feedback-hooks.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/references/pas-feedback-hooks.md
@@ -4,9 +4,9 @@
 
 Set up PAS feedback hooks when ALL of these are true:
 
-1. The project has `pas-config.yaml` with `feedback: enabled`
+1. The project has `.pas/config.yaml` with `feedback: enabled`
 2. The process uses agents (not solo orchestrator-only)
-3. Agents carry `library/self-evaluation/SKILL.md`
+3. Agents carry `.pas/library/self-evaluation/SKILL.md`
 
 ## The Two Standard Hooks
 
@@ -35,7 +35,7 @@ AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // "unknown"')
 AGENT_TRANSCRIPT=$(echo "$INPUT" | jq -r '.agent_transcript_path // empty')
 
 # Guard: only run in PAS repos with feedback enabled
-PAS_CONFIG="$CWD/pas-config.yaml"
+PAS_CONFIG="$CWD/.pas/config.yaml"
 if [ ! -f "$PAS_CONFIG" ]; then
   exit 0
 fi
@@ -46,7 +46,7 @@ if [ "$FEEDBACK_STATUS" != "enabled" ]; then
 fi
 
 # Find active workspace (sort-by-mtime approach)
-WORKSPACE_DIR="$CWD/workspace"
+WORKSPACE_DIR="$CWD/.pas/workspace"
 if [ ! -d "$WORKSPACE_DIR" ]; then
   exit 0
 fi
@@ -96,7 +96,7 @@ Agent '${AGENT_ID}' is shutting down without writing self-evaluation.
 Before stopping, write your self-evaluation to:
   ${FEEDBACK_DIR}/${AGENT_ID}.md
 
-Use library/self-evaluation/SKILL.md for the format.
+Use .pas/library/self-evaluation/SKILL.md for the format.
 If nothing went wrong, write "No issues detected."
 EOF
 exit 2
@@ -114,10 +114,10 @@ exit 2
 
 The canonical version lives at `plugins/pas/hooks/route-feedback.sh`. Key features:
 
-- `resolve_target_path()` searches `$CWD/processes/`, then `$CWD/plugins/` as fallback for process/agent/skill targets
+- `resolve_target_path()` searches `$CWD/.pas/processes/`, then `$CWD/plugins/` as fallback for process/agent/skill targets
 - `framework)` case returns sentinel `__framework__` which triggers `route_framework_signal()`
 - `route_framework_signal()` files GitHub issues via `gh issue create` for signals marked `Route: github-issue`
-- Guards: checks `gh auth status` before attempting; logs to `$CWD/feedback/framework-routing.log`
+- Guards: checks `gh auth status` before attempting; logs to `$CWD/.pas/feedback/framework-routing.log`
 - Processed feedback files are marked with `.routed` companion file instead of deleted
 
 Refer to the deployed script at `${CLAUDE_PLUGIN_ROOT}/hooks/route-feedback.sh` for the full implementation.

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/references/script-patterns.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-hooks/references/script-patterns.md
@@ -136,7 +136,7 @@ Without this, a Stop hook that returns `decision: "block"` will fire again when 
 For hooks that should only fire in PAS-enabled repos:
 
 ```bash
-PAS_CONFIG="$CWD/pas-config.yaml"
+PAS_CONFIG="$CWD/.pas/config.yaml"
 if [ ! -f "$PAS_CONFIG" ]; then
   exit 0  # Not a PAS repo, skip
 fi
@@ -184,7 +184,7 @@ fi
 
 ```bash
 find_active_workspace() {
-  local workspace_dir="$CWD/workspace"
+  local workspace_dir="$CWD/.pas/workspace"
   if [ ! -d "$workspace_dir" ]; then
     return 1
   fi
@@ -209,8 +209,8 @@ Note: includes both Linux (`stat -c %Y`) and macOS (`stat -f %m`) fallback.
 **Always `mkdir -p` before writing logs:**
 
 ```bash
-mkdir -p "$CWD/feedback"
-echo "[$(date -Iseconds)] WARNING: ..." >> "$CWD/feedback/warnings.log"
+mkdir -p "$CWD/.pas/feedback"
+echo "[$(date -Iseconds)] WARNING: ..." >> "$CWD/.pas/feedback/warnings.log"
 ```
 
 ## Path References

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
@@ -19,8 +19,8 @@ This skill IS the execution framework. When generating plans for process creatio
 
 When creating a process, the workspace reflects the **running process** (PAS), not the artifact being created:
 
-- Correct: `workspace/pas/create-songwriting-process/`
-- Incorrect: `workspace/songwriting/create-process/`
+- Correct: `.pas/workspace/pas/create-songwriting-process/`
+- Incorrect: `.pas/workspace/songwriting/create-process/`
 
 The workspace slug should describe the task: `create-{name}-process`. The `process` field in status.yaml is always `pas` (since the PAS orchestrator is running).
 
@@ -43,7 +43,7 @@ Never assume you understand what the user wants. Ask clarifying questions until 
 
 If the process requires domain knowledge from raw source material (transcripts, documentation, course content):
 
-1. Create `processes/{name}/reference/` directory
+1. Create `.pas/processes/{name}/reference/` directory
 2. Store the original source material in `reference/source/` — this is the authoritative knowledge base
 3. Analyze the source material to determine the best reference format:
    - If already well-structured: use directly, no distillation needed
@@ -76,7 +76,7 @@ For simple processes (1-3 phases, similar skills), the orchestrator handles ever
 
 ### 5. Select Orchestration Pattern
 
-Read the orchestration decision matrix. If `library/orchestration/SKILL.md` doesn't exist in the user's project yet, bootstrap it by copying from the PAS plugin's library (the `library/` directory next to `processes/` in the plugin). Then apply the decision matrix:
+Read the orchestration decision matrix. If `.pas/library/orchestration/SKILL.md` doesn't exist in the user's project yet, bootstrap it by copying from the PAS plugin's library (the `library/` directory next to `processes/` in the plugin). Then apply the decision matrix:
 
 | Agents | Discussion needed? | Parallel phases? | Pattern |
 |--------|-------------------|-------------------|---------|
@@ -105,7 +105,7 @@ bash ${CLAUDE_SKILL_DIR}/scripts/pas-create-process \
 
 Repeatable flags: `--phase` (required, at least one), `--input` (required, at least one).
 
-Optional: `--base-dir` sets the root directory for output (default: current directory). Use for test isolation to avoid generating into the project's real `processes/` directory.
+Optional: `--base-dir` sets the root directory for output (default: current directory). Use for test isolation to avoid generating into the project's real `.pas/processes/` directory.
 
 This creates the process directory (process.md, mode files, references/, feedback/), thin launcher, and changelog.
 
@@ -121,7 +121,7 @@ For each agent determined in step 4, use `creating-agents/SKILL.md`:
 
 Evaluate whether the process needs lifecycle hooks:
 
-- **Feedback hooks**: If `pas-config.yaml` has `feedback: enabled`, the PAS plugin's hooks handle self-eval and routing automatically. No per-process hooks needed for feedback.
+- **Feedback hooks**: If `.pas/config.yaml` has `feedback: enabled`, the PAS plugin's hooks handle self-eval and routing automatically. No per-process hooks needed for feedback.
 - **Domain-specific guards**: Does any phase need pre-conditions checked before tool use? (e.g., block destructive commands, validate inputs)
 - **Lifecycle automation**: Should anything happen automatically at session start, agent stop, or task completion?
 

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/scripts/pas-create-process
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/scripts/pas-create-process
@@ -101,7 +101,7 @@ for input in "${INPUTS[@]}"; do
 done
 
 # Build target path
-TARGET="${BASE_DIR:+${BASE_DIR}/}processes/${NAME}"
+TARGET="${BASE_DIR:+${BASE_DIR}/}.pas/processes/${NAME}"
 
 # Check directory conflict
 if [[ -d "$TARGET" && "$FORCE" != true ]]; then
@@ -185,7 +185,7 @@ EOF
 
   cat <<EOF
 
-status_file: workspace/${NAME}/{slug}/status.yaml
+status_file: .pas/workspace/${NAME}/{slug}/status.yaml
 ---
 
 # ${TITLE}
@@ -217,7 +217,7 @@ EOF
 
   echo "## Lifecycle"
   echo ""
-  echo "This process follows the shared lifecycle protocol. Read \`library/orchestration/lifecycle.md\` for:"
+  echo "This process follows the shared lifecycle protocol. Read \`.pas/library/orchestration/lifecycle.md\` for:"
   echo ""
   echo "- Workspace creation and status tracking"
   echo "- Task creation (required — create a Claude Code task for each phase)"
@@ -300,9 +300,9 @@ name: ${NAME}
 description: ${GOAL}
 ---
 
-Read \`processes/${NAME}/process.md\` for the process definition.
-Read \`library/orchestration/lifecycle.md\` for shared lifecycle protocol (workspace, tasks, status, shutdown).
-Read the orchestration pattern from \`library/orchestration/\` as specified in the process.
+Read \`.pas/processes/${NAME}/process.md\` for the process definition.
+Read \`.pas/library/orchestration/lifecycle.md\` for shared lifecycle protocol (workspace, tasks, status, shutdown).
+Read the orchestration pattern from \`.pas/library/orchestration/\` as specified in the process.
 Execute.
 EOF
 echo "  Created ${LAUNCHER_DIR}/SKILL.md"

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/SKILL.md
@@ -23,9 +23,9 @@ Define what the skill does:
 
 Before creating a new skill:
 
-- Check existing skills within the owning agent (`processes/{process}/agents/{agent}/skills/`)
-- Check existing skills within the process (`processes/{process}/`)
-- Check `library/` for global skills that already do this
+- Check existing skills within the owning agent (`.pas/processes/{process}/agents/{agent}/skills/`)
+- Check existing skills within the process (`.pas/processes/{process}/`)
+- Check `.pas/library/` for global skills that already do this
 - If overlap exists: extend the existing skill or reference it instead of duplicating
 
 ### 3. Apply Granularity Heuristics
@@ -79,4 +79,4 @@ After creating the skill, check if it should be in `library/` instead:
 - Is this exact skill already used by another agent in a different process?
 - Would a second process/agent benefit from this skill without modification?
 
-If yes to either: move to `library/{skill-name}/` and reference from both locations. If no: keep it local. Skills start local and graduate to the library only when reuse is proven (used in 2+ places).
+If yes to either: move to `.pas/library/{skill-name}/` and reference from both locations. If no: keep it local. Skills start local and graduate to the library only when reuse is proven (used in 2+ places).

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/scripts/pas-create-skill
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-skills/scripts/pas-create-skill
@@ -84,7 +84,7 @@ if [[ ! "$NAME" =~ ^[a-z][a-z0-9-]*$ ]]; then
 fi
 
 # Build target path
-TARGET="${BASE_DIR:+${BASE_DIR}/}processes/${PROCESS}/agents/${AGENT}/skills/${NAME}"
+TARGET="${BASE_DIR:+${BASE_DIR}/}.pas/processes/${PROCESS}/agents/${AGENT}/skills/${NAME}"
 
 # Check directory conflict
 if [[ -d "$TARGET" && "$FORCE" != true ]]; then

--- a/plugins/pas/processes/pas/process.md
+++ b/plugins/pas/processes/pas/process.md
@@ -22,7 +22,7 @@ phases:
     output: created/modified PAS artifacts
     gate: user approves result
 
-status_file: workspace/pas/{slug}/status.yaml
+status_file: .pas/workspace/pas/{slug}/status.yaml
 ---
 
 # PAS Management Process

--- a/plugins/pas/skills/pas/SKILL.md
+++ b/plugins/pas/skills/pas/SKILL.md
@@ -16,7 +16,7 @@ Based on the user's message, read the appropriate skill from `${CLAUDE_SKILL_DIR
 - **Modifying existing** (change, update, add phase): read the target artifact, then use creation skills
 - **Running a process** (run article, start pipeline): point to thin launcher (e.g., `/article`)
 - **Visualizing a process** (visualize, overview, view, HTML, diagram): read `${CLAUDE_SKILL_DIR}/../../library/visualize-process/SKILL.md`
-- **Information query** (what exists, status, list): survey `processes/`, `library/`, `workspace/`
+- **Information query** (what exists, status, list): survey `.pas/processes/`, `.pas/library/`, `.pas/workspace/`
 
 ## Conversation Style
 
@@ -27,22 +27,24 @@ Based on the user's message, read the appropriate skill from `${CLAUDE_SKILL_DIR
 
 ## First-Run Detection
 
-If `pas-config.yaml` does not exist at the project root, run self-setup:
+If `.pas/config.yaml` does not exist at the project root, run self-setup:
 
-1. Create `pas-config.yaml` with defaults: `feedback: enabled`, `feedback_disabled_at: ~`
-2. Create `library/` with core skills by copying from the PAS plugin's library: `self-evaluation/`, `message-routing/`, `orchestration/`
-3. Create `workspace/` directory
-4. Confirm to the user: "PAS initialized — library, workspace, and config are ready."
+1. Create `.pas/config.yaml` with defaults: `feedback: enabled`, `feedback_disabled_at: ~`
+2. Create `.pas/library/` with core skills by copying from the PAS plugin's library: `self-evaluation/`, `message-routing/`, `orchestration/`
+3. Create `.pas/workspace/` directory
+4. Confirm to the user: "PAS initialized — .pas/ directory created with config, library, and workspace."
+
+If old-style `pas-config.yaml` exists at root but `.pas/` does not, auto-migrate: move config, library, workspace, processes, and feedback into `.pas/`.
 
 Hooks (`check-self-eval.sh`, `route-feedback.sh`) are loaded automatically by Claude Code from the plugin's `hooks/hooks.json` — no project-level configuration needed.
 
 ## Frustration Detection
 
-If `pas-config.yaml` shows `feedback: disabled` and the user expresses frustration about repeated issues, offer to re-enable feedback collection.
+If `.pas/config.yaml` shows `feedback: disabled` and the user expresses frustration about repeated issues, offer to re-enable feedback collection.
 
 ## Library Bootstrap
 
-First-Run Detection handles initial library setup. When creating a new process that references library skills not yet in the user's project `library/`, copy them from `${CLAUDE_SKILL_DIR}/../../library/`. This makes the user's project self-contained.
+First-Run Detection handles initial library setup. When creating a new process that references library skills not yet in the user's project `.pas/library/`, copy them from `${CLAUDE_SKILL_DIR}/../../library/`. This makes the user's project self-contained.
 
 ## Framework Feedback
 


### PR DESCRIPTION
## Summary

- All PAS project-level artifacts (config, library, workspace, processes, feedback) now live under a single `.pas/` root directory instead of scattered at project root
- Backward-compatible auto-migration: hooks detect old-style layout and move artifacts automatically via `migrate_to_pas_dir()` in guards.sh
- Test harness expanded from 45 to 59 tests, including 7 new migration tests
- Generation scripts output to `.pas/processes/` and `.pas/library/`; all hook scripts, library skills, and creation docs updated

## Test plan

- [x] `bash plugins/pas/hooks/tests/test-hooks.sh` → 59/59 pass
- [ ] Verify migration on a project with old-style layout (root-level `workspace/`, `library/`, `processes/`)
- [ ] Verify fresh bootstrap creates artifacts under `.pas/`

Roadmap alignment: Milestone 2 (first-run simplification), Milestone 5 (config location)