### PR TITLE
Fix .pas/ convention discovery in /pas router

### DIFF
--- a/plugins/pas/skills/pas/SKILL.md
+++ b/plugins/pas/skills/pas/SKILL.md
@@ -6,6 +6,17 @@ description: Use when creating, managing, or improving processes, agents, and sk
 Read `${CLAUDE_SKILL_DIR}/../../processes/pas/process.md` for the process definition.
 Read the orchestration pattern from `${CLAUDE_SKILL_DIR}/../../library/orchestration/` as specified in the process.
 
+## Project Convention
+
+All PAS artifacts in the user's project live under `.pas/` at the project root:
+
+- `.pas/config.yaml` — framework configuration
+- `.pas/processes/` — process definitions, agents, skills, feedback backlogs
+- `.pas/library/` — shared skills (orchestration, self-evaluation, message-routing)
+- `.pas/workspace/` — execution instances, status tracking, session feedback
+
+When reading, modifying, or creating artifacts — always resolve paths relative to `.pas/`.
+
 ## Quick Routing
 
 Based on the user's message, read the appropriate skill from `${CLAUDE_SKILL_DIR}/../../processes/pas/agents/orchestrator/skills/`:
@@ -13,7 +24,7 @@ Based on the user's message, read the appropriate skill from `${CLAUDE_SKILL_DIR
 - **Creating something new** (process, pipeline, workflow): read `creating-processes/SKILL.md`
 - **Creating hooks** (hook, lifecycle, guard, automation, when something happens): read `creating-hooks/SKILL.md`
 - **Applying feedback** (upgrade, improve, what feedback exists): read `applying-feedback/SKILL.md`
-- **Modifying existing** (change, update, add phase): read the target artifact, then use creation skills
+- **Modifying existing** (change, update, add phase): find the target in `.pas/processes/` or `.pas/library/`, read it, then use creation skills to apply the modification
 - **Running a process** (run article, start pipeline): point to thin launcher (e.g., `/article`)
 - **Visualizing a process** (visualize, overview, view, HTML, diagram): read `${CLAUDE_SKILL_DIR}/../../library/visualize-process/SKILL.md`
 - **Information query** (what exists, status, list): survey `.pas/processes/`, `.pas/library/`, `.pas/workspace/`


### PR DESCRIPTION
## Summary

- Adds a **Project Convention** section to the `/pas` entry point (`plugins/pas/skills/pas/SKILL.md`) that establishes the `.pas/` directory structure before any routing decision
- Expands the "Modifying existing" route with explicit `.pas/processes/` and `.pas/library/` search locations

When `/pas` was invoked in another repo to upgrade a skill, agents had no guidance on where artifacts live. The router mentioned `.pas/` paths in some routes (Information query, First-Run Detection) but not the "Modifying existing" route that handles skill upgrades.

## Test plan

- [ ] Install plugin in a repo with `.pas/` directory, invoke `/pas` to upgrade a skill — agent should discover artifacts under `.pas/`
- [ ] Invoke `/pas` for information query — still works as before
- [ ] Invoke `/pas` in a repo without `.pas/` — first-run detection still triggers