### PR TITLE
Version auto-bump, library dedup, README walkthrough (v1.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,19 +5,26 @@
   },
   "metadata": {
     "description": "PAS (Process, Agent, Skill) framework for building agentic workflows",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
       "name": "pas",
       "source": "./plugins/pas",
       "description": "Framework for building agentic workflows with composable processes, agents, and skills. Provides /pas command to create and manage automated pipelines.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "Zoran Spirkovski"
       },
       "license": "MIT",
-      "keywords": ["framework", "agents", "skills", "processes", "workflow", "automation"],
+      "keywords": [
+        "framework",
+        "agents",
+        "skills",
+        "processes",
+        "workflow",
+        "automation"
+      ],
       "category": "productivity"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,63 @@ PAS will ask clarifying questions (one at a time, brainstorming-style), then cre
 - A thin launcher so you can run it with a slash command
 - Library skills (orchestration patterns, self-evaluation, feedback routing)
 
-On first use, PAS creates `pas-config.yaml`, `library/`, and `workspace/` directories in your project root.
+On first use, PAS creates `.pas/config.yaml` and `.pas/workspace/` in your project root.
+
+## Walkthrough
+
+A full lifecycle example using the code review pipeline from Quick Start.
+
+### 1. Create a Process
+
+```
+/pas:pas I want to build a code review pipeline
+```
+
+PAS asks clarifying questions — how many reviewers, what languages, which quality gates — then generates everything:
+
+```
+.pas/
+  config.yaml
+  workspace/
+  processes/code-review/
+    process.md              # Phases, agents, gates
+    agents/
+      orchestrator/         # Coordinates the pipeline
+      reviewer/             # Reviews code changes
+    modes/
+      supervised.md
+      autonomous.md
+    feedback/backlog/
+.claude/skills/code-review/
+    SKILL.md                # Thin launcher — invoke with /code-review
+```
+
+`process.md` defines the phases (e.g., diff analysis, review, summary), the gates between them, and which agent handles each phase. Agents get identities, tools, and skills. The thin launcher in `.claude/skills/` lets you run the whole pipeline with a single slash command.
+
+### 2. Run the Process
+
+```
+/code-review
+```
+
+The orchestrator reads `process.md`, creates a workspace instance at `.pas/workspace/code-review/{slug}/`, and executes each phase in order. Gates between phases enforce quality checks — a phase only advances when its gate criteria are met. The workspace tracks pipeline state in `status.yaml` so runs are resumable.
+
+### 3. Feedback Loop
+
+At shutdown, every agent writes self-evaluation signals:
+
+- **PPU** — a workflow improvement (e.g., "check test coverage before style review")
+- **OQI** — a quality issue in output (e.g., "missed edge case in error handling review")
+- **GATE** — a change that should not be made (stability guard)
+- **STA** — a behavior that must not regress (stability anchor)
+
+Signals route automatically to the relevant artifact's `feedback/backlog/`. To review and apply them:
+
+```
+/pas:pas what feedback exists?
+```
+
+PAS shows accumulated signals grouped by artifact, then applies improvements directly — updating process definitions, agent instructions, or skill logic. Each run makes the pipeline better.
 
 ## Core Concepts
 

--- a/plugins/pas/.claude-plugin/plugin.json
+++ b/plugins/pas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pas",
   "description": "Process-Agent-Skill framework for building agentic workflows. Create automated pipelines with composable processes, agents, and skills that improve through feedback.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Zoran Spirkovski"
   },

--- a/plugins/pas/hooks/lib/bump-version.sh
+++ b/plugins/pas/hooks/lib/bump-version.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Bump the patch version across all PAS distribution files.
+# Run from the repo root. Outputs the new version string to stdout.
+
+PLUGIN_JSON="plugins/pas/.claude-plugin/plugin.json"
+MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+
+# --- Read current version ---
+
+read_version() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.version' "$PLUGIN_JSON"
+  else
+    sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$PLUGIN_JSON" | head -1
+  fi
+}
+
+CURRENT=$(read_version)
+if [ -z "$CURRENT" ]; then
+  echo "bump-version: could not read version from $PLUGIN_JSON" >&2
+  exit 1
+fi
+
+# --- Increment patch ---
+
+MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+MINOR=$(echo "$CURRENT" | cut -d. -f2)
+PATCH=$(echo "$CURRENT" | cut -d. -f3)
+NEW_PATCH=$((PATCH + 1))
+NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+
+# --- Write to all locations ---
+
+write_with_jq() {
+  local file="$1" filter="$2"
+  local tmp="${file}.tmp"
+  jq "$filter" "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+write_with_sed() {
+  local file="$1" old="$2" new="$3"
+  sed -i "s/\"$old\"/\"$new\"/" "$file"
+}
+
+if command -v jq >/dev/null 2>&1; then
+  write_with_jq "$PLUGIN_JSON"      ".version = \"$NEW_VERSION\""
+  write_with_jq "$MARKETPLACE_JSON"  ".metadata.version = \"$NEW_VERSION\" | .plugins[0].version = \"$NEW_VERSION\""
+else
+  write_with_sed "$PLUGIN_JSON"      "$CURRENT" "$NEW_VERSION"
+  write_with_sed "$MARKETPLACE_JSON" "$CURRENT" "$NEW_VERSION"
+fi
+
+echo "$NEW_VERSION"

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -547,10 +547,10 @@ assert_dir_exists "$GEN_DIR/.pas/processes/test-proc" \
 assert_file_exists "$GEN_DIR/.pas/processes/test-proc/process.md" \
   "pas-create-process: process.md exists"
 
-# 8b: process.md references .pas/ paths
+# 8b: process.md references plugin library
 assert_file_contains "$GEN_DIR/.pas/processes/test-proc/process.md" \
-  ".pas/library/orchestration/lifecycle.md" \
-  "pas-create-process: process.md references .pas/library/lifecycle.md"
+  "CLAUDE_PLUGIN_ROOT}/library/orchestration/lifecycle.md" \
+  "pas-create-process: process.md references plugin library lifecycle.md"
 
 assert_file_contains "$GEN_DIR/.pas/processes/test-proc/process.md" \
   "status_file: .pas/workspace/test-proc/" \
@@ -565,8 +565,8 @@ assert_file_contains "$GEN_DIR/.claude/skills/test-proc/SKILL.md" \
   "pas-create-process: thin launcher references .pas/processes/"
 
 assert_file_contains "$GEN_DIR/.claude/skills/test-proc/SKILL.md" \
-  ".pas/library/orchestration/lifecycle.md" \
-  "pas-create-process: thin launcher references .pas/library/"
+  "CLAUDE_PLUGIN_ROOT}/library/orchestration/lifecycle.md" \
+  "pas-create-process: thin launcher references plugin library"
 
 # 8d: No artifacts at project root
 assert_dir_not_exists "$GEN_DIR/processes" \

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/SKILL.md
@@ -76,7 +76,7 @@ For simple processes (1-3 phases, similar skills), the orchestrator handles ever
 
 ### 5. Select Orchestration Pattern
 
-Read the orchestration decision matrix. If `.pas/library/orchestration/SKILL.md` doesn't exist in the user's project yet, bootstrap it by copying from the PAS plugin's library (the `library/` directory next to `processes/` in the plugin). Then apply the decision matrix:
+Read `${CLAUDE_PLUGIN_ROOT}/library/orchestration/SKILL.md` for the decision matrix. Then apply it:
 
 | Agents | Discussion needed? | Parallel phases? | Pattern |
 |--------|-------------------|-------------------|---------|

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/scripts/pas-create-process
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/creating-processes/scripts/pas-create-process
@@ -217,7 +217,7 @@ EOF
 
   echo "## Lifecycle"
   echo ""
-  echo "This process follows the shared lifecycle protocol. Read \`.pas/library/orchestration/lifecycle.md\` for:"
+  echo "This process follows the shared lifecycle protocol. Read \`\${CLAUDE_PLUGIN_ROOT}/library/orchestration/lifecycle.md\` for:"
   echo ""
   echo "- Workspace creation and status tracking"
   echo "- Task creation (required — create a Claude Code task for each phase)"
@@ -301,8 +301,8 @@ description: ${GOAL}
 ---
 
 Read \`.pas/processes/${NAME}/process.md\` for the process definition.
-Read \`.pas/library/orchestration/lifecycle.md\` for shared lifecycle protocol (workspace, tasks, status, shutdown).
-Read the orchestration pattern from \`.pas/library/orchestration/\` as specified in the process.
+Read \`\${CLAUDE_PLUGIN_ROOT}/library/orchestration/lifecycle.md\` for shared lifecycle protocol (workspace, tasks, status, shutdown).
+Read the orchestration pattern from \`\${CLAUDE_PLUGIN_ROOT}/library/orchestration/\` as specified in the process.
 Execute.
 EOF
 echo "  Created ${LAUNCHER_DIR}/SKILL.md"

--- a/plugins/pas/skills/pas/SKILL.md
+++ b/plugins/pas/skills/pas/SKILL.md
@@ -12,7 +12,6 @@ All PAS artifacts in the user's project live under `.pas/` at the project root:
 
 - `.pas/config.yaml` — framework configuration
 - `.pas/processes/` — process definitions, agents, skills, feedback backlogs
-- `.pas/library/` — shared skills (orchestration, self-evaluation, message-routing)
 - `.pas/workspace/` — execution instances, status tracking, session feedback
 
 When reading, modifying, or creating artifacts — always resolve paths relative to `.pas/`.
@@ -41,9 +40,8 @@ Based on the user's message, read the appropriate skill from `${CLAUDE_SKILL_DIR
 If `.pas/config.yaml` does not exist at the project root, run self-setup:
 
 1. Create `.pas/config.yaml` with defaults: `feedback: enabled`, `feedback_disabled_at: ~`
-2. Create `.pas/library/` with core skills by copying from the PAS plugin's library: `self-evaluation/`, `message-routing/`, `orchestration/`
-3. Create `.pas/workspace/` directory
-4. Confirm to the user: "PAS initialized — .pas/ directory created with config, library, and workspace."
+2. Create `.pas/workspace/` directory
+3. Confirm to the user: "PAS initialized — `.pas/` directory created with config and workspace."
 
 If old-style `pas-config.yaml` exists at root but `.pas/` does not, auto-migrate: move config, library, workspace, processes, and feedback into `.pas/`.
 
@@ -55,7 +53,7 @@ If `.pas/config.yaml` shows `feedback: disabled` and the user expresses frustrat
 
 ## Library Bootstrap
 
-First-Run Detection handles initial library setup. When creating a new process that references library skills not yet in the user's project `.pas/library/`, copy them from `${CLAUDE_SKILL_DIR}/../../library/`. This makes the user's project self-contained.
+Processes reference the plugin library directly via `${CLAUDE_PLUGIN_ROOT}/library/` — no copying needed. The library lives in the plugin and is always available at runtime.
 
 ## Framework Feedback
 


### PR DESCRIPTION
## Summary

- Add `bump-version.sh` script for automatic patch version increment across plugin.json and marketplace.json
- Library dedup: generated processes now reference `${CLAUDE_PLUGIN_ROOT}/library/` directly instead of copying library to project
- First-run detection simplified: creates only `.pas/config.yaml` and `.pas/workspace/` (no library copy)
- Add end-to-end walkthrough section to README showing create → run → feedback lifecycle
- Update test assertions for new library paths (59/59 pass)
- Completes Milestone 2 (Reliability & Library Dedup)

## Test plan

- [ ] Run `bash plugins/pas/hooks/tests/test-hooks.sh` — 59/59 pass
- [ ] Run `bash plugins/pas/hooks/lib/bump-version.sh` — outputs incremented version
- [ ] Verify generated thin launchers reference `${CLAUDE_PLUGIN_ROOT}/library/`
- [ ] Verify README walkthrough section renders correctly