### PR TITLE
Fix Milestone 3: hook safety & stability (P0 session/subagent crashes)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "PAS (Process, Agent, Skill) framework for building agentic workflows",
-    "version": "1.3.2"
+    "version": "1.3.3"
   },
   "plugins": [
     {
       "name": "pas",
       "source": "./plugins/pas",
       "description": "Framework for building agentic workflows with composable processes, agents, and skills. Provides /pas command to create and manage automated pipelines.",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "Zoran Spirkovski"
       },

--- a/plugins/pas/.claude-plugin/plugin.json
+++ b/plugins/pas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pas",
   "description": "Process-Agent-Skill framework for building agentic workflows. Create automated pipelines with composable processes, agents, and skills that improve through feedback.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": {
     "name": "Zoran Spirkovski"
   },

--- a/plugins/pas/hooks/changelog.md
+++ b/plugins/pas/hooks/changelog.md
@@ -1,0 +1,27 @@
+# Hooks Changelog
+
+## 2026-04-16 — Cycle 14 / Milestone 3: Hook Safety & Stability
+
+Triggered by: 14 GitHub issues — sessions silently disabled from worktrees, hooks crashing on missing yaml fields, `SubagentStop` derailing non-PAS subagents, completion gate deadlocking with no diagnostic, framework signals filed on product repos. Plus cycle-13 dx-specialist OQI-02 (idle-shutdown self-eval), bundled.
+
+Pattern: every hook script assumed `cwd == project root` and used `set -euo pipefail` on `grep` pipelines that legitimately match nothing. Subagent-context detection was absent, so any subagent in a PAS-enabled repo was treated as a PAS process agent. One root cause family expressed across hooks, scaffolds, and the inherited self-eval contract.
+
+Changes (11 commits, 30 new tests, harness now 117 / 0 fail):
+
+- `lib/guards.sh`: defensive default for `CLAUDE_PLUGIN_ROOT`; new `resolve_pas_project_root` (cwd → `.pas/config.yaml` walk → `git rev-parse --show-toplevel` worktree fallback); new `safe_grep_field` helper; new `guard_agent_in_active_process` (PAS-vs-non-PAS scoping); `guard_active_workspace` now resolves via `$PAS_PROJECT_ROOT` (#64, #70-F1, #70-F2)
+- `pas-session-start.sh`: tolerate missing `instance:` / `status:` / `process:` fields; print `MISSING_FIELDS` warning instead of silently degrading; skip lifecycle injection when `agent_id` is non-empty (#54, #58, #38, #68 — context-injection side)
+- `check-self-eval.sh`: fix `grep -c || echo 0` integer-comparison crash; gate on `guard_agent_in_active_process` so non-PAS subagents pass through silently; preserve substantive `last_assistant_message` (>200 chars, no summary keyword) instead of blocking with elided summary; SUBAGENT NOTE carve-out + `tr -d '[:space:]'` for `LAST_MSG_LEN` (#55, #38, #67, #68, #71, cycle-13 dx-specialist OQI-02)
+- `lib/workspace.sh`: session-id-first resolution in `find_active_workspace_status` — match `current_session:` field before falling back to mtime; resolves wrong-workspace bugs in multi-instance projects (#52)
+- `verify-completion-gate.sh`: absolute paths in failure diagnostics; `Resolved PAS_PROJECT_ROOT:` line for diagnosability; jointly with the workspace + project-root fixes, closes the worktree deadlock (#70-F4)
+- `verify-task-completion.sh`: new `[PAS] Phase: <name>` matcher reads `output_files` from status.yaml and blocks completion when files are missing — first phase-deliverable enforcement gate (#49)
+- `route-feedback.sh`: read repo from new `framework_signal_repo:` config key (defaults to `ZoranSpirkovski/PAS`); refuse to file when target is empty; audit log entry written to `framework-routing.log` before every `gh issue create` (#59)
+- `pas-config.yaml`: add `framework_signal_repo: ZoranSpirkovski/PAS` so consumers cannot accidentally route PAS-internal signals onto product repos
+- `processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md`: Step 3 mandates `AskUserQuestion` with four labeled options; new Step 13 codifies routing rules (in-repo edits vs framework GitHub issues vs local backlog) so the skill cannot be the source of a wrong-repo filing (#30, #40, #41)
+- `tests/test-hooks.sh`: 30 new tests across the 8 affected scripts; `tests/fixtures/worktree-setup.sh` and `tests/fixtures/agent-type-status.sh` added
+- `plugin.json`, `marketplace.json`: version auto-bumped from 1.3.2 → 1.3.3 by `bump-version.sh`
+
+Closed: #38, #49, #52, #54, #55, #58, #59, #64, #67, #68, #70 (findings 1, 2, 4, 7), #71, #30, #40, #41. Duplicates closed via constituent fix: #31, #33, #56, #57, #61 (and #66 — community-manager admin).
+
+Known residual (deferred to cycle 15): SessionStart lifecycle text leaks into Agent-tool subagent context despite the `agent_id` skip in `pas-session-start.sh`. Hook-layer enforcement holds (the rogue feedback file is benign, gates do not block), but the directive text reaches the subagent. Tracked as a fresh issue; root-cause hypothesis is that Claude Code's SessionStart payload may not populate `agent_id` for Agent-tool subagents.
+
+Deferred to M5: #70 findings 5 (generator emits cwd-relative paths), 6 (self-evaluation/SKILL.md cwd contract). Deferred to M7: #70 findings 8, 9, 10. Deferred to M6: #50, #34. Cycle-14 dogfood signals filed for M4: TaskUpdate ownership-change auto-broadcasts, agent task_assignment auto-claim, subagent self-eval filename mismatch.

--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -62,7 +62,7 @@ fi
 # exploration text. If the agent's last_assistant_message is long AND not
 # a known summary boilerplate, treat it as substantive — bypass the gate
 # and emit an audit line so the bypass is visible.
-LAST_MSG_LEN=$(echo -n "$LAST_MSG" | wc -c | tr -d ' ')
+LAST_MSG_LEN=$(printf '%s' "$LAST_MSG" | wc -c | tr -d '[:space:]')
 if [ -n "$LAST_MSG" ] && [ "$LAST_MSG_LEN" -gt 200 ]; then
   # Known summary boilerplates that should NOT count as substantive.
   # Match the exact strings observed in #71 / #68 / #38 reports.

--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -33,24 +33,28 @@ else
   fi
 fi
 
-# Secondary check (P1): scan transcript for inline signal patterns
+# Secondary check (P1): scan transcript for inline signal patterns.
+# Note: `grep -c` writes "0" to stdout AND exits 1 on zero matches, so the
+# old `|| echo 0` captured a two-line "0\n0" that broke the integer test.
 if [ -n "$AGENT_TRANSCRIPT" ] && [ -f "$AGENT_TRANSCRIPT" ]; then
-  SIGNAL_COUNT=$(grep -cE '\[(PPU|OQI|GATE|STA)-[0-9]+\]' "$AGENT_TRANSCRIPT" 2>/dev/null || echo 0)
+  SIGNAL_COUNT=$(grep -cE '\[(PPU|OQI|GATE|STA)-[0-9]+\]' "$AGENT_TRANSCRIPT" 2>/dev/null) || SIGNAL_COUNT=0
   if [ "$SIGNAL_COUNT" -gt 0 ]; then
     exit 0  # Found inline signals — agent did self-eval in conversation
   fi
 fi
 
-# No self-eval found — block subagent from stopping
+# No self-eval found — block subagent from stopping.
 cat >&2 <<EOF
-SELF-EVALUATION MISSING
+PAS feedback hook: agent '${AGENT_ID}' is shutting down without writing self-evaluation.
 
-Agent '${AGENT_ID}' is shutting down without writing self-evaluation.
+This is required when feedback is enabled in .pas/config.yaml.
 
-Before stopping, write your self-evaluation to:
+To resolve, write your evaluation to:
   ${FEEDBACK_DIR}/${AGENT_ID}.md
 
-Use .pas/library/self-evaluation/SKILL.md for the format.
-If nothing went wrong, write "No issues detected."
+If nothing went wrong, the file may contain just: "No issues detected."
+
+Format reference: .pas/library/self-evaluation/SKILL.md
+To disable feedback for this project: edit .pas/config.yaml → feedback: disabled
 EOF
 exit 2

--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -11,9 +11,22 @@ source "$SCRIPT_DIR/lib/guards.sh"
 guard_parse_input || exit 0
 
 AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // "unknown"')
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty')
 AGENT_TRANSCRIPT=$(echo "$INPUT" | jq -r '.agent_transcript_path // empty')
+LAST_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // empty')
 
 guard_feedback_enabled || exit 0
+
+# Scope this hook to PAS-process agents only. Generic Explore / Plan /
+# general-purpose subagents get spawned all the time during PAS sessions
+# and must not be blocked or have their work treated as PAS feedback
+# (#38, #67, #68). guard_agent_in_active_process is safe-fail (returns 0)
+# when agent_type is empty/unknown or the workspace allowlist is
+# unresolvable, preserving over-blocking on older CC versions.
+if ! guard_agent_in_active_process "$AGENT_TYPE" "$SCRIPT_DIR"; then
+  exit 0  # Not a PAS-process agent — silently skip
+fi
+
 guard_active_workspace "$SCRIPT_DIR" || exit 0
 
 if [ ! -d "$FEEDBACK_DIR" ]; then
@@ -40,6 +53,22 @@ if [ -n "$AGENT_TRANSCRIPT" ] && [ -f "$AGENT_TRANSCRIPT" ]; then
   SIGNAL_COUNT=$(grep -cE '\[(PPU|OQI|GATE|STA)-[0-9]+\]' "$AGENT_TRANSCRIPT" 2>/dev/null) || SIGNAL_COUNT=0
   if [ "$SIGNAL_COUNT" -gt 0 ]; then
     exit 0  # Found inline signals — agent did self-eval in conversation
+  fi
+fi
+
+# Tertiary check (#71): substantive plain-text response detected.
+# The bug we're fixing: parents were receiving a hook-injected "Self-
+# evaluation written" summary INSTEAD of the agent's actual review/
+# exploration text. If the agent's last_assistant_message is long AND not
+# a known summary boilerplate, treat it as substantive — bypass the gate
+# and emit an audit line so the bypass is visible.
+LAST_MSG_LEN=$(echo -n "$LAST_MSG" | wc -c | tr -d ' ')
+if [ -n "$LAST_MSG" ] && [ "$LAST_MSG_LEN" -gt 200 ]; then
+  # Known summary boilerplates that should NOT count as substantive.
+  # Match the exact strings observed in #71 / #68 / #38 reports.
+  if ! echo "$LAST_MSG" | head -c 400 | grep -qiE 'self-evaluation written|self-evaluation has been written|no issues detected|written to the requested location|feedback file written|written\. (no issues|task tracking)'; then
+    echo "PAS feedback hook INFO: substantive response detected (${LAST_MSG_LEN} chars), gate bypassed for agent '${AGENT_ID}'" >&2
+    exit 0
   fi
 fi
 

--- a/plugins/pas/hooks/lib/guards.sh
+++ b/plugins/pas/hooks/lib/guards.sh
@@ -134,6 +134,61 @@ guard_feedback_enabled() {
   fi
 }
 
+# Check that the given agent type is one declared in the active process's
+# status.yaml (i.e. a PAS-spawned agent, not a generic Explore/Plan/etc).
+# Args:
+#   $1 — agent_type from the SubagentStop payload (jq '.agent_type // empty')
+#   $2 — script_dir (passed through to guard_active_workspace)
+# Returns 0 when the agent is in the active PAS process's allowlist,
+# non-zero otherwise (caller should `exit 0` to silently skip).
+#
+# SAFE-FAIL: empty/unset agent_type → return 0 (treat as PAS agent). This
+# preserves existing over-blocking behavior on CC versions that don't
+# populate the field, instead of silently weakening the gate.
+guard_agent_in_active_process() {
+  local agent_type="$1"
+  local script_dir="$2"
+
+  # Empty/unknown → safe-fail to "treat as PAS agent" (over-block direction)
+  if [ -z "$agent_type" ] || [ "$agent_type" = "unknown" ] || [ "$agent_type" = "null" ]; then
+    return 0
+  fi
+
+  # If we can't resolve a workspace, can't check the allowlist — safe-fail
+  # to over-block; caller's guard_active_workspace will exit 0 naturally
+  # if there's truly no workspace.
+  if ! guard_active_workspace "$script_dir" 2>/dev/null; then
+    return 0
+  fi
+
+  local pas_agents
+  # status.yaml shape: `agent: name` (scalar) OR `agent: [a, b, c]` (list).
+  # Strip brackets/commas; emit every name on its own line.
+  pas_agents=$(grep '^[[:space:]]*agent:' "$ACTIVE_STATUS" 2>/dev/null \
+    | sed 's/^[[:space:]]*agent:[[:space:]]*//' \
+    | tr -d '[]' \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+    | grep -v '^$' \
+    | sort -u)
+
+  # Empty allowlist → safe-fail (something's wrong with status.yaml)
+  if [ -z "$pas_agents" ]; then
+    return 0
+  fi
+
+  # Orchestrator is always a PAS agent even if not declared in any phase
+  if [ "$agent_type" = "orchestrator" ]; then
+    return 0
+  fi
+
+  if echo "$pas_agents" | grep -qx "$agent_type"; then
+    return 0
+  fi
+
+  return 1
+}
+
 # Find active workspace using the shared workspace resolution function.
 # Sets ACTIVE_STATUS, ACTIVE_WORKSPACE, FEEDBACK_DIR.
 # Uses PAS_PROJECT_ROOT (set by guard_pas_project) so worktree-cwd sessions

--- a/plugins/pas/hooks/lib/guards.sh
+++ b/plugins/pas/hooks/lib/guards.sh
@@ -138,6 +138,9 @@ guard_feedback_enabled() {
 # Sets ACTIVE_STATUS, ACTIVE_WORKSPACE, FEEDBACK_DIR.
 # Uses PAS_PROJECT_ROOT (set by guard_pas_project) so worktree-cwd sessions
 # resolve to the main checkout's .pas/workspace/.
+# When INPUT carries a session_id, the resolver prefers the workspace whose
+# current_session: matches — this closes the multi-instance picking-the-
+# wrong-workspace bug (#52).
 # Returns 1 if no workspace found.
 guard_active_workspace() {
   local script_dir="$1"
@@ -153,7 +156,19 @@ guard_active_workspace() {
     return 1
   fi
 
-  ACTIVE_STATUS=$(find_active_workspace_status "$WORKSPACE_DIR") || return 1
+  # Derive short session id from INPUT (if present); pass to the resolver
+  # so multi-instance resolution picks the workspace this session is
+  # working on, not the most-recently-touched sibling.
+  local session_short=""
+  if [ -n "${INPUT:-}" ]; then
+    local full_session
+    full_session=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+    if [ -n "$full_session" ]; then
+      session_short=$(echo "$full_session" | cut -c1-8)
+    fi
+  fi
+
+  ACTIVE_STATUS=$(find_active_workspace_status "$WORKSPACE_DIR" "$session_short") || return 1
   ACTIVE_WORKSPACE=$(dirname "$ACTIVE_STATUS")
   FEEDBACK_DIR="$ACTIVE_WORKSPACE/feedback"
 }

--- a/plugins/pas/hooks/lib/guards.sh
+++ b/plugins/pas/hooks/lib/guards.sh
@@ -5,6 +5,51 @@
 # All PAS project-level artifacts live under this directory.
 PAS_ROOT=".pas"
 
+# Defensive default for CLAUDE_PLUGIN_ROOT — the harness substitutes this in
+# hooks.json command paths but does not always export it as an env var.
+# Falls back to two-levels-up from this lib file (i.e. plugins/pas/).
+: "${CLAUDE_PLUGIN_ROOT:=$(cd "${BASH_SOURCE[0]%/*}/../.." 2>/dev/null && pwd || echo "")}"
+export CLAUDE_PLUGIN_ROOT
+
+# Resolve the PAS project root by walking up from a candidate cwd until
+# .pas/config.yaml is found, then falling back to git's worktree root.
+# Echoes the resolved root on stdout; returns non-zero if nothing matches.
+resolve_pas_project_root() {
+  local candidate="${1:-${CWD:-${CLAUDE_PROJECT_DIR:-$(pwd)}}}"
+
+  # Walk up from candidate
+  local dir="$candidate"
+  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    if [ -f "$dir/$PAS_ROOT/config.yaml" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+
+  # Worktree fallback: when running inside a worktree, .pas/ may live at the
+  # main worktree root. --show-toplevel returns the worktree's working tree,
+  # not the shared .git dir (which would be wrong for hosting .pas/).
+  if command -v git >/dev/null 2>&1; then
+    local worktree_root
+    worktree_root=$(cd "$candidate" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || return 1
+    if [ -n "$worktree_root" ] && [ -f "$worktree_root/$PAS_ROOT/config.yaml" ]; then
+      echo "$worktree_root"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# Crash-resistant `grep | head | awk` field extractor for status.yaml.
+# Returns empty string on missing field instead of failing under set -e/pipefail.
+safe_grep_field() {
+  local file="$1"
+  local key="$2"
+  grep "^${key}:" "$file" 2>/dev/null | head -1 | awk '{print $2}' || true
+}
+
 # Parse JSON input from stdin. Sets CWD and exposes raw INPUT.
 # Returns 1 if jq is missing or JSON is invalid.
 guard_parse_input() {
@@ -41,11 +86,16 @@ migrate_to_pas_dir() {
 }
 
 # Check that this is a PAS project (.pas/config.yaml exists).
-# Auto-migrates old-style layout if detected.
+# Auto-migrates old-style layout if detected. Also handles worktrees and
+# subdirectory invocations by walking up and falling back to git-worktree-root.
+# Sets PAS_PROJECT_ROOT to the resolved project root (may differ from CWD).
 # Returns 1 if not a PAS project.
 guard_pas_project() {
+  # Fast path: $CWD itself is a PAS root
   PAS_CONFIG="$CWD/$PAS_ROOT/config.yaml"
   if [ -f "$PAS_CONFIG" ]; then
+    PAS_PROJECT_ROOT="$CWD"
+    export PAS_PROJECT_ROOT
     return 0
   fi
 
@@ -54,8 +104,20 @@ guard_pas_project() {
     migrate_to_pas_dir
     PAS_CONFIG="$CWD/$PAS_ROOT/config.yaml"
     if [ -f "$PAS_CONFIG" ]; then
+      PAS_PROJECT_ROOT="$CWD"
+      export PAS_PROJECT_ROOT
       return 0
     fi
+  fi
+
+  # Worktree / subdirectory fallback: walk up and try git-worktree resolver.
+  local resolved
+  resolved=$(resolve_pas_project_root "$CWD") || return 1
+  if [ -n "$resolved" ] && [ -f "$resolved/$PAS_ROOT/config.yaml" ]; then
+    PAS_PROJECT_ROOT="$resolved"
+    PAS_CONFIG="$resolved/$PAS_ROOT/config.yaml"
+    export PAS_PROJECT_ROOT
+    return 0
   fi
 
   return 1
@@ -74,12 +136,19 @@ guard_feedback_enabled() {
 
 # Find active workspace using the shared workspace resolution function.
 # Sets ACTIVE_STATUS, ACTIVE_WORKSPACE, FEEDBACK_DIR.
+# Uses PAS_PROJECT_ROOT (set by guard_pas_project) so worktree-cwd sessions
+# resolve to the main checkout's .pas/workspace/.
 # Returns 1 if no workspace found.
 guard_active_workspace() {
   local script_dir="$1"
   source "$script_dir/lib/workspace.sh"
 
-  WORKSPACE_DIR="$CWD/$PAS_ROOT/workspace"
+  # Ensure PAS_PROJECT_ROOT is resolved (may be unset if caller skipped guard_pas_project).
+  if [ -z "${PAS_PROJECT_ROOT:-}" ]; then
+    guard_pas_project || return 1
+  fi
+
+  WORKSPACE_DIR="$PAS_PROJECT_ROOT/$PAS_ROOT/workspace"
   if [ ! -d "$WORKSPACE_DIR" ]; then
     return 1
   fi

--- a/plugins/pas/hooks/lib/workspace.sh
+++ b/plugins/pas/hooks/lib/workspace.sh
@@ -1,13 +1,37 @@
 #!/usr/bin/env bash
 # Shared workspace detection utility for PAS hooks.
 
+# Resolve the active workspace's status.yaml.
+# Args:
+#   $1 — workspace dir (e.g. $PAS_PROJECT_ROOT/.pas/workspace)
+#   $2 — session_id (optional, short form). When non-empty, prefer the
+#        workspace whose current_session: matches this id. This protects
+#        against the multi-instance bug (#52) where mtime would pick a
+#        sibling workspace that an unrelated session was working on.
+# Echoes the path to status.yaml; returns non-zero if nothing matches.
 find_active_workspace_status() {
   local workspace_dir="$1"
+  local session_id="${2:-}"
   if [ ! -d "$workspace_dir" ]; then
     return 1
   fi
 
   local result=""
+
+  # Pass 0: when a session id is provided, find the workspace whose
+  # current_session matches. Wins over mtime/in_progress passes.
+  if [ -n "$session_id" ]; then
+    result=$(find "$workspace_dir" -name "status.yaml" -print 2>/dev/null | while read -r f; do
+      if grep -q "^current_session:[[:space:]]*${session_id}\b" "$f" 2>/dev/null; then
+        echo "$f"
+        break
+      fi
+    done | head -1)
+    if [ -n "$result" ]; then
+      echo "$result"
+      return 0
+    fi
+  fi
 
   # Pass 1: prefer status.yaml files with status: in_progress (most recent by mtime)
   result=$(find "$workspace_dir" -name "status.yaml" -print 2>/dev/null | while read -r f; do

--- a/plugins/pas/hooks/pas-session-start.sh
+++ b/plugins/pas/hooks/pas-session-start.sh
@@ -12,6 +12,17 @@ source "$SCRIPT_DIR/lib/guards.sh"
 guard_parse_input || exit 0
 guard_pas_project || exit 0
 
+# Subagent guard (#38, #68): when SessionStart fires inside a subagent
+# context, skip the lifecycle injection. The heredoc's "MUST follow this
+# lifecycle / hooks will block you" text was making generic Explore /
+# general-purpose subagents short-circuit into the PAS shutdown ritual
+# instead of doing their actual task. CC v2.1.69+ exposes agent_id in
+# subagent SessionStart events; absence means orchestrator session.
+HOOK_AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty')
+if [ -n "$HOOK_AGENT_ID" ] && [ "$HOOK_AGENT_ID" != "null" ]; then
+  exit 0  # Subagent context — do not inject PAS lifecycle text
+fi
+
 FEEDBACK_STATUS=$(grep -o 'feedback:[[:space:]]*\w*' "$PAS_CONFIG" | head -1 | awk '{print $NF}')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 

--- a/plugins/pas/hooks/pas-session-start.sh
+++ b/plugins/pas/hooks/pas-session-start.sh
@@ -89,11 +89,37 @@ EOF
 # If there's an active workspace, show its status
 if [ -n "$ACTIVE_STATUS" ]; then
   ACTIVE_WORKSPACE=$(dirname "$ACTIVE_STATUS")
-  TOP_STATUS=$(grep '^status:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
-  PROCESS_NAME=$(grep '^process:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
-  INSTANCE=$(grep '^instance:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
+
+  # Use safe_grep_field (from lib/guards.sh) so missing fields don't crash
+  # the script under set -euo pipefail.
+  TOP_STATUS=$(safe_grep_field "$ACTIVE_STATUS" status)
+  PROCESS_NAME=$(safe_grep_field "$ACTIVE_STATUS" process)
+  INSTANCE=$(safe_grep_field "$ACTIVE_STATUS" instance)
+
+  # Accumulate missing-field warnings; default to useful values so the
+  # display is never just "Active workspace: / (status: )".
+  MISSING_FIELDS=""
+  if [ -z "$TOP_STATUS" ]; then
+    MISSING_FIELDS="status"
+    TOP_STATUS="unknown"
+  fi
+  if [ -z "$PROCESS_NAME" ]; then
+    MISSING_FIELDS="${MISSING_FIELDS:+$MISSING_FIELDS, }process"
+  fi
+  if [ -z "$INSTANCE" ]; then
+    INSTANCE=$(basename "$ACTIVE_WORKSPACE")
+    MISSING_FIELDS="${MISSING_FIELDS:+$MISSING_FIELDS, }instance"
+  fi
 
   echo ""
+  if [ -n "$MISSING_FIELDS" ]; then
+    echo "PAS workspace detected at: ${ACTIVE_WORKSPACE}"
+    echo "  Status file: ${ACTIVE_STATUS}"
+    echo "  Missing required fields: ${MISSING_FIELDS}"
+    echo "  See: library/orchestration/lifecycle.md (status.yaml schema)"
+    echo "  Continuing with derived values — fix status.yaml to silence this warning."
+    echo ""
+  fi
   echo "Active workspace: ${PROCESS_NAME}/${INSTANCE} (status: ${TOP_STATUS})"
   echo "Path: ${ACTIVE_WORKSPACE}"
 

--- a/plugins/pas/hooks/pas-session-start.sh
+++ b/plugins/pas/hooks/pas-session-start.sh
@@ -95,6 +95,14 @@ SHUTDOWN (after all phases complete):
 ENFORCEMENT: Hooks will block you from stopping or completing tasks if deliverables are missing.
 CREATION ROUTING: When the user wants to create a process, agent, skill, or workflow, offer /pas:pas as the tool to do it. PAS provides structured creation with brainstorming, proper scaffolding, and feedback integration.
 Feedback files MUST include your session ID (${SESSION_SHORT:-unknown}) in the filename.
+
+SUBAGENT NOTE: The above lifecycle applies to the PRIMARY orchestrator session
+only. If you are a subagent spawned via the Agent tool (Explore, Plan,
+general-purpose, or any other subagent type), DO NOT follow this lifecycle.
+Return your task output as plain text and do NOT write any self-evaluation
+files. The PAS hooks scope themselves to known PAS-process agents and will
+not block you. PAS-process agents are spawned via TeamCreate (not Agent);
+if you were spawned via Agent, you are not one of them.
 EOF
 
 # If there's an active workspace, show its status

--- a/plugins/pas/hooks/route-feedback.sh
+++ b/plugins/pas/hooks/route-feedback.sh
@@ -65,7 +65,7 @@ route_signal() {
 route_framework_signal() {
   local signal_block="$1"
   local signal_id="$2"
-  local log_dir="$CWD/$PAS_ROOT/feedback"
+  local log_dir="${PAS_PROJECT_ROOT:-$CWD}/$PAS_ROOT/feedback"
   mkdir -p "$log_dir"
 
   # Guard: only route signals marked for GitHub issue creation
@@ -73,6 +73,29 @@ route_framework_signal() {
     echo "[$(date -Iseconds)] INFO: Framework signal ${signal_id} not marked 'Route: github-issue', skipping" >> "$log_dir/framework-routing.log" 2>/dev/null || true
     return 0
   fi
+
+  # Resolve target repo from config — must NEVER fall through to the host
+  # project's repo. The plugin's pas-config.yaml ships with
+  # framework_signal_repo set; an empty value is a hard refusal so we never
+  # silently file framework signals on a downstream consumer's product repo.
+  local target_repo=""
+  if [ -n "${PAS_CONFIG:-}" ] && [ -f "$PAS_CONFIG" ]; then
+    target_repo=$(grep '^framework_signal_repo:' "$PAS_CONFIG" 2>/dev/null | head -1 | awk '{print $2}')
+  fi
+  # Fall back to the framework default (read from the plugin install dir,
+  # never from $CWD) when the project config doesn't carry the field.
+  if [ -z "$target_repo" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/pas-config.yaml" ]; then
+    target_repo=$(grep '^framework_signal_repo:' "$CLAUDE_PLUGIN_ROOT/pas-config.yaml" 2>/dev/null | head -1 | awk '{print $2}')
+  fi
+
+  if [ -z "$target_repo" ]; then
+    echo "[$(date -Iseconds)] REFUSED: framework_signal_repo unresolved; will NOT file ${signal_id} (refusing to default to host project repo)" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+    return 0
+  fi
+
+  # Audit: record the resolved repo BEFORE the gh call so any future
+  # mis-routing regression is visible in the log.
+  echo "[$(date -Iseconds)] INFO: Filing ${signal_id} on repo ${target_repo}" >> "$log_dir/framework-routing.log" 2>/dev/null || true
 
   # Guard: check gh CLI is available and authenticated
   if ! command -v gh >/dev/null 2>&1; then
@@ -96,12 +119,12 @@ route_framework_signal() {
   summary=$(echo "$summary" | cut -c1-80)
 
   # File as GitHub issue
-  if gh issue create --repo ZoranSpirkovski/PAS \
+  if gh issue create --repo "$target_repo" \
     --title "[Feedback] ${signal_id}: ${summary}" \
     --body "$signal_block" >/dev/null 2>&1; then
-    echo "[$(date -Iseconds)] OK: Filed ${signal_id} as GitHub issue" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+    echo "[$(date -Iseconds)] OK: Filed ${signal_id} as GitHub issue on ${target_repo}" >> "$log_dir/framework-routing.log" 2>/dev/null || true
   else
-    echo "[$(date -Iseconds)] ERROR: Failed to file ${signal_id} as GitHub issue" >> "$log_dir/framework-routing.log" 2>/dev/null || true
+    echo "[$(date -Iseconds)] ERROR: Failed to file ${signal_id} as GitHub issue on ${target_repo}" >> "$log_dir/framework-routing.log" 2>/dev/null || true
   fi
 }
 

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -713,6 +713,224 @@ fi
 rm -rf "$MIGDIR"
 
 # =========================================================================
+# Section: C04 — session-id-first workspace resolution
+# =========================================================================
+
+printf "\n${BOLD}C04. session-id-first workspace resolution${RESET}\n"
+
+# Two sibling workspaces under the same process; resolver should pick the
+# one whose current_session matches the given id, NOT the most-recently-
+# touched one (which was the pre-fix behavior — bug #52).
+C04DIR=$(mktemp -d)
+mkdir -p "$C04DIR/.pas/workspace/proc/inst-a/feedback"
+mkdir -p "$C04DIR/.pas/workspace/proc/inst-b/feedback"
+printf 'feedback: enabled\n' > "$C04DIR/.pas/config.yaml"
+
+# inst-a: older workspace, matches session id 'aaaa1111'
+cat > "$C04DIR/.pas/workspace/proc/inst-a/status.yaml" <<'EOF'
+process: proc
+instance: inst-a
+status: in_progress
+current_session: aaaa1111
+
+phases:
+  discovery:
+    status: pending
+EOF
+
+# Sleep then write inst-b LATER so it has newer mtime and would win mtime fight
+sleep 0.1
+cat > "$C04DIR/.pas/workspace/proc/inst-b/status.yaml" <<'EOF'
+process: proc
+instance: inst-b
+status: in_progress
+current_session: bbbb2222
+
+phases:
+  discovery:
+    status: pending
+EOF
+
+# T-C04-1: session id matches inst-a → resolver picks inst-a even though
+# inst-b was just written and has newer mtime
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$C04DIR/.pas/workspace' aaaa1111")
+if echo "$RESULT" | grep -q "inst-a/status.yaml"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C04-1: session id beats mtime (picks matching workspace)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C04-1: expected inst-a, got '$RESULT'")
+  printf "  ${RED}FAIL${RESET} C04-1: picked wrong workspace (got: '%s')\n" "$RESULT"
+fi
+
+# T-C04-2: no current_session anywhere — fall back to mtime (back-compat)
+C04DIR2=$(mktemp -d)
+mkdir -p "$C04DIR2/.pas/workspace/proc/inst-x"
+mkdir -p "$C04DIR2/.pas/workspace/proc/inst-y"
+cat > "$C04DIR2/.pas/workspace/proc/inst-x/status.yaml" <<'EOF'
+process: proc
+instance: inst-x
+status: in_progress
+EOF
+sleep 0.1
+cat > "$C04DIR2/.pas/workspace/proc/inst-y/status.yaml" <<'EOF'
+process: proc
+instance: inst-y
+status: in_progress
+EOF
+
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$C04DIR2/.pas/workspace' nosuchid")
+if echo "$RESULT" | grep -q "inst-y/status.yaml"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C04-2: no match on session id → falls back to mtime (back-compat)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C04-2: expected inst-y (newer mtime), got '$RESULT'")
+  printf "  ${RED}FAIL${RESET} C04-2: mtime fallback broken (got: '%s')\n" "$RESULT"
+fi
+
+# T-C04-3: empty session_id arg → falls back to mtime (sessions without ids)
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$C04DIR2/.pas/workspace' ''")
+if echo "$RESULT" | grep -q "inst-y/status.yaml"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C04-3: empty session_id → mtime fallback\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C04-3: empty session_id broke resolution (got: '$RESULT')")
+  printf "  ${RED}FAIL${RESET} C04-3: empty session_id (got: '%s')\n" "$RESULT"
+fi
+
+# T-C04-4: matching workspace has status pending, not in_progress — session
+# id still wins over the status filter.
+C04DIR4=$(mktemp -d)
+mkdir -p "$C04DIR4/.pas/workspace/proc/inst-pending"
+mkdir -p "$C04DIR4/.pas/workspace/proc/inst-active"
+cat > "$C04DIR4/.pas/workspace/proc/inst-pending/status.yaml" <<'EOF'
+process: proc
+instance: inst-pending
+status: pending
+current_session: ccccdddd
+EOF
+sleep 0.1
+cat > "$C04DIR4/.pas/workspace/proc/inst-active/status.yaml" <<'EOF'
+process: proc
+instance: inst-active
+status: in_progress
+current_session: eeeeffff
+EOF
+
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$C04DIR4/.pas/workspace' ccccdddd")
+if echo "$RESULT" | grep -q "inst-pending/status.yaml"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C04-4: session id beats in_progress status filter\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C04-4: expected inst-pending, got '$RESULT'")
+  printf "  ${RED}FAIL${RESET} C04-4: session id didn't beat status filter (got: '%s')\n" "$RESULT"
+fi
+
+rm -rf "$C04DIR" "$C04DIR2" "$C04DIR4"
+
+# =========================================================================
+# Section: C07 — route-feedback.sh framework_signal_repo enforcement
+# =========================================================================
+
+printf "\n${BOLD}C07. route-feedback.sh framework_signal_repo enforcement${RESET}\n"
+
+# T-C07-1: signal with valid framework_signal_repo → audit log records target.
+# We DON'T actually call gh issue create (no auth in test); the route function
+# logs the target repo BEFORE the gh call so we can assert it from log alone.
+C07DIR=$(mktemp -d)
+mkdir -p "$C07DIR/.pas/workspace/proc/inst-c07/feedback"
+cat > "$C07DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+framework_signal_repo: ZoranSpirkovski/PAS
+EOF
+cat > "$C07DIR/.pas/workspace/proc/inst-c07/status.yaml" <<'EOF'
+process: proc
+instance: inst-c07
+status: in_progress
+
+phases:
+  discovery:
+    status: completed
+EOF
+
+cat > "$C07DIR/.pas/workspace/proc/inst-c07/feedback/agent-c07.md" <<'EOF'
+[OQI-99]
+Target: framework:pas
+Route: github-issue
+Degraded: test signal for routing audit
+Priority: LOW
+EOF
+
+run_hook "route-feedback.sh" \
+  "{\"cwd\":\"$C07DIR\"}" \
+  0 "C07-1: routing with valid config → exit 0"
+
+if [ -f "$C07DIR/.pas/feedback/framework-routing.log" ] && \
+   grep -q "Filing OQI-99 on repo ZoranSpirkovski/PAS" "$C07DIR/.pas/feedback/framework-routing.log"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C07-1: audit log records target repo before gh call\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C07-1: audit log missing 'Filing OQI-99 on repo ZoranSpirkovski/PAS'")
+  printf "  ${RED}FAIL${RESET} C07-1: audit log missing target-repo line\n"
+fi
+
+# T-C07-2: signal with EMPTY framework_signal_repo → REFUSED, no gh call.
+# Achieved by clearing both project config AND CLAUDE_PLUGIN_ROOT so the
+# fallback can't supply a default either.
+C07DIR2=$(mktemp -d)
+mkdir -p "$C07DIR2/.pas/workspace/proc/inst-c07b/feedback"
+cat > "$C07DIR2/.pas/config.yaml" <<'EOF'
+feedback: enabled
+framework_signal_repo:
+EOF
+cat > "$C07DIR2/.pas/workspace/proc/inst-c07b/status.yaml" <<'EOF'
+process: proc
+instance: inst-c07b
+status: in_progress
+
+phases:
+  discovery:
+    status: completed
+EOF
+
+cat > "$C07DIR2/.pas/workspace/proc/inst-c07b/feedback/agent-c07b.md" <<'EOF'
+[OQI-98]
+Target: framework:pas
+Route: github-issue
+Degraded: test signal that should NOT be filed
+Priority: LOW
+EOF
+
+# Run with CLAUDE_PLUGIN_ROOT pointed at an empty fake plugin so fallback
+# also returns nothing — the "must refuse" path.
+FAKE_PLUGIN=$(mktemp -d)
+RESULT=$(echo "{\"cwd\":\"$C07DIR2\"}" | env CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN" bash "$HOOKS_DIR/route-feedback.sh" 2>/dev/null; echo "exit=$?")
+if echo "$RESULT" | grep -q 'exit=0'; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C07-2: hook exits 0 on empty config (no crash)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C07-2: hook crashed on empty framework_signal_repo: $RESULT")
+  printf "  ${RED}FAIL${RESET} C07-2: hook crashed (got: %s)\n" "$RESULT"
+fi
+
+if [ -f "$C07DIR2/.pas/feedback/framework-routing.log" ] && \
+   grep -q "REFUSED:.*OQI-98" "$C07DIR2/.pas/feedback/framework-routing.log"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C07-2: REFUSED log entry written for empty config\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C07-2: missing REFUSED log entry for OQI-98")
+  printf "  ${RED}FAIL${RESET} C07-2: REFUSED entry missing\n"
+fi
+
+rm -rf "$C07DIR" "$C07DIR2" "$FAKE_PLUGIN"
+
+# =========================================================================
 # Section: C03 — check-self-eval.sh grep -c integer comparison fix
 # =========================================================================
 

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -712,6 +712,83 @@ fi
 rm -rf "$MIGDIR"
 
 # =========================================================================
+# Section: C01 — lib/guards.sh defensive defaults + resolve_pas_project_root
+# =========================================================================
+
+printf "\n${BOLD}C01. lib/guards.sh foundation${RESET}\n"
+
+# T-C01-1: CLAUDE_PLUGIN_ROOT defensive default fires when unset
+# Run a fresh bash with the var unset; sourcing guards.sh must populate it.
+RESULT=$(env -u CLAUDE_PLUGIN_ROOT bash -c "source '$HOOKS_DIR/lib/guards.sh' && echo \"\$CLAUDE_PLUGIN_ROOT\"")
+if [ -n "$RESULT" ] && [ -d "$RESULT" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C01-1: CLAUDE_PLUGIN_ROOT defensive default sets a real path\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C01-1: defensive default failed (got: '$RESULT')")
+  printf "  ${RED}FAIL${RESET} C01-1: CLAUDE_PLUGIN_ROOT default (got: '%s')\n" "$RESULT"
+fi
+
+# T-C01-2: resolve_pas_project_root from cwd containing .pas/config.yaml
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/guards.sh' && resolve_pas_project_root '$TESTDIR'")
+if [ "$RESULT" = "$TESTDIR" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C01-2: resolve_pas_project_root from PAS-root cwd\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C01-2: expected '$TESTDIR', got '$RESULT'")
+  printf "  ${RED}FAIL${RESET} C01-2: resolve from PAS-root cwd (got: '%s')\n" "$RESULT"
+fi
+
+# T-C01-3: walk up from a deep subdirectory
+mkdir -p "$TESTDIR/sub/deeper/nest"
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/guards.sh' && resolve_pas_project_root '$TESTDIR/sub/deeper/nest'")
+if [ "$RESULT" = "$TESTDIR" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C01-3: resolve walks up from deep subdirectory\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C01-3: expected '$TESTDIR', got '$RESULT'")
+  printf "  ${RED}FAIL${RESET} C01-3: walk up from subdir (got: '%s')\n" "$RESULT"
+fi
+
+# T-C01-4: git worktree fallback — worktree dir has no .pas/, main dir does
+WTBASE=$(mktemp -d)
+( cd "$WTBASE" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -m init -q ) >/dev/null 2>&1
+mkdir -p "$WTBASE/.pas"
+printf 'feedback: enabled\n' > "$WTBASE/.pas/config.yaml"
+( cd "$WTBASE" && git worktree add -q "$WTBASE/.wt" -b c01-test-branch ) >/dev/null 2>&1
+if [ -d "$WTBASE/.wt" ]; then
+  RESULT=$(bash -c "source '$HOOKS_DIR/lib/guards.sh' && resolve_pas_project_root '$WTBASE/.wt'")
+  # Resolve symlinks for comparison (macOS/Linux tmpdir realpath quirks)
+  EXPECTED_REAL=$(cd "$WTBASE" && pwd -P)
+  RESULT_REAL=$(cd "$RESULT" 2>/dev/null && pwd -P || echo "$RESULT")
+  if [ "$RESULT_REAL" = "$EXPECTED_REAL" ]; then
+    PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${RESET} C01-4: resolve falls back to git --show-toplevel from worktree\n"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("C01-4: expected '$EXPECTED_REAL', got '$RESULT_REAL'")
+    printf "  ${RED}FAIL${RESET} C01-4: worktree fallback (got: '%s')\n" "$RESULT_REAL"
+  fi
+else
+  # Worktree creation failed — skip but don't fail the suite
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C01-4: worktree fixture unavailable (skipped, but no failure)\n"
+fi
+rm -rf "$WTBASE"
+
+# T-C01-5: from /tmp (non-PAS, non-git) returns non-zero
+if bash -c "source '$HOOKS_DIR/lib/guards.sh' && resolve_pas_project_root /tmp" >/dev/null 2>&1; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C01-5: expected non-zero exit when no PAS root resolvable")
+  printf "  ${RED}FAIL${RESET} C01-5: should return non-zero from /tmp\n"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C01-5: returns non-zero when no PAS root resolvable\n"
+fi
+
+# =========================================================================
 # Summary
 # =========================================================================
 

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -713,6 +713,254 @@ fi
 rm -rf "$MIGDIR"
 
 # =========================================================================
+# Section: C05 — agent_type scoping + #71 substantive-message bypass
+# =========================================================================
+
+printf "\n${BOLD}C05. agent_type scoping for non-PAS subagents${RESET}\n"
+
+# Setup a workspace whose status.yaml declares specific PAS agents
+C05DIR=$(mktemp -d)
+mkdir -p "$C05DIR/.pas/workspace/proc/inst-c05/feedback"
+printf 'feedback: enabled\n' > "$C05DIR/.pas/config.yaml"
+cat > "$C05DIR/.pas/workspace/proc/inst-c05/status.yaml" <<'EOF'
+process: proc
+instance: inst-c05
+status: in_progress
+current_session: c05test1
+
+phases:
+  discovery:
+    status: in_progress
+    agent: [framework-architect, dx-specialist]
+  planning:
+    status: pending
+    agent: framework-architect
+EOF
+
+# T-C05-1: agent_type "Explore" (not in status.yaml allowlist), no feedback
+# file → SubagentStop exits 0 silently (non-PAS passthrough). This is the
+# core bug from #67/#68/#38.
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C05DIR\",\"agent_id\":\"some-explore-id\",\"agent_type\":\"Explore\"}" \
+  0 "C05-1: agent_type Explore → exit 0 (non-PAS passthrough)"
+
+# T-C05-2: agent_type framework-architect (in allowlist), no feedback file
+# → SubagentStop exits 2 (PAS scoping retained — gate still works).
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C05DIR\",\"agent_id\":\"framework-architect\",\"agent_type\":\"framework-architect\"}" \
+  2 "C05-2: PAS-defined agent without feedback → exit 2 (gate enforced)"
+
+assert_stderr_contains "shutting down without writing self-evaluation" \
+  "C05-2: stderr shows the standard block message"
+
+# T-C05-3: PAS agent with feedback file present → exit 0
+echo "No issues detected." > "$C05DIR/.pas/workspace/proc/inst-c05/feedback/framework-architect.md"
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C05DIR\",\"agent_id\":\"framework-architect\",\"agent_type\":\"framework-architect\"}" \
+  0 "C05-3: PAS agent with feedback file → exit 0"
+
+# T-C05-4: empty agent_type → SAFE-FAIL to "treat as PAS agent" (over-block).
+# A previously-passing fixture (no feedback file for unknown agent) must
+# still block — confirms we did NOT silently weaken the gate.
+rm -f "$C05DIR/.pas/workspace/proc/inst-c05/feedback/framework-architect.md"
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C05DIR\",\"agent_id\":\"unknown-agent\",\"agent_type\":\"\"}" \
+  2 "C05-4: empty agent_type → safe-fail over-block (gate not weakened)"
+
+# T-C05-5: SessionStart with non-empty agent_id → no PAS lifecycle text
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$C05DIR\",\"source\":\"startup\",\"session_id\":\"c05sub1\",\"agent_id\":\"some-subagent-id\"}" \
+  0 "C05-5: SessionStart with agent_id → exit 0"
+
+if grep -q "PAS Framework Active" /tmp/test-hook-stdout 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C05-5: SessionStart should NOT inject 'PAS Framework Active' for subagents")
+  printf "  ${RED}FAIL${RESET} C05-5: PAS lifecycle text leaked into subagent context\n"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C05-5: no PAS lifecycle text in subagent SessionStart\n"
+fi
+
+# T-C05-6: SessionStart with empty agent_id (orchestrator) → full text injected
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$C05DIR\",\"source\":\"startup\",\"session_id\":\"c05orch1\"}" \
+  0 "C05-6: SessionStart without agent_id → exit 0"
+
+assert_stdout_contains "PAS Framework Active" \
+  "C05-6: orchestrator SessionStart still injects lifecycle text"
+
+# T-C05-7: substantive last_assistant_message (>200 chars, no summary
+# keywords) → exits 0 with audit-line on stderr (#71 substantive bypass).
+LONG_MSG="This is a long substantive review message that contains the actual findings the parent agent needs to receive. It deliberately avoids any of the boilerplate summary phrases that the bypass heuristic looks for, so the gate must let this through. The message is well over two hundred characters so the length check passes too."
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C05DIR\",\"agent_id\":\"framework-architect\",\"agent_type\":\"framework-architect\",\"last_assistant_message\":\"$LONG_MSG\"}" \
+  0 "C05-7: substantive response → exit 0 (#71 bypass)"
+
+assert_stderr_contains "substantive response detected" \
+  "C05-7: stderr emits audit line so bypass is visible"
+
+# T-C05-8: short summary boilerplate → still blocks (the bug we're fixing).
+# "Self-evaluation written. No issues detected during this review." is
+# exactly the elision text from the #71 bug report.
+SHORT_MSG="Self-evaluation written. No issues detected during this review."
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C05DIR\",\"agent_id\":\"framework-architect\",\"agent_type\":\"framework-architect\",\"last_assistant_message\":\"$SHORT_MSG\"}" \
+  2 "C05-8: summary-boilerplate response → exit 2 (block — that's the bug)"
+
+rm -rf "$C05DIR"
+
+# =========================================================================
+# Section: C06 — verify-completion-gate absolute-path diagnostics
+# =========================================================================
+
+printf "\n${BOLD}C06. verify-completion-gate absolute-path diagnostics${RESET}\n"
+
+C06DIR=$(mktemp -d)
+mkdir -p "$C06DIR/.pas/workspace/proc/inst-c06/feedback"
+printf 'feedback: enabled\n' > "$C06DIR/.pas/config.yaml"
+cat > "$C06DIR/.pas/workspace/proc/inst-c06/status.yaml" <<'EOF'
+process: proc
+instance: inst-c06
+status: in_progress
+current_session: c06test1
+
+phases:
+  discovery:
+    status: completed
+EOF
+
+# T-C06-1: missing orchestrator feedback → stderr contains an absolute path
+# (starts with /), not just the bare filename.
+run_hook "verify-completion-gate.sh" \
+  "{\"cwd\":\"$C06DIR\",\"stop_hook_active\":false,\"session_id\":\"c06test1\"}" \
+  2 "C06-1: missing orchestrator → exit 2"
+
+if grep -qE "Orchestrator self-evaluation missing: /" /tmp/test-hook-stderr 2>/dev/null; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C06-1: stderr names absolute path (starts with /)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C06-1: stderr missing absolute orchestrator path")
+  printf "  ${RED}FAIL${RESET} C06-1: stderr missing absolute path\n"
+fi
+
+# T-C06-2: stderr includes the resolver diagnostic line
+assert_stderr_contains "Resolved PAS_PROJECT_ROOT:" \
+  "C06-2: stderr exposes PAS_PROJECT_ROOT for diagnosability"
+
+assert_stderr_contains "Checked feedback dir:" \
+  "C06-2: stderr names the feedback dir actually checked"
+
+# T-C06-3: worktree fixture — agent writes feedback in main checkout's .pas/,
+# hook called from worktree cwd → exits 0 because PAS_PROJECT_ROOT resolves
+# back to the main worktree (closes #70-F4 deadlock + makes the diagnostic
+# the only thing the user sees on a true mismatch, not a phantom failure).
+WTBASE=$(mktemp -d)
+( cd "$WTBASE" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -m init -q ) >/dev/null 2>&1
+mkdir -p "$WTBASE/.pas/workspace/proc/inst-wt/feedback"
+printf 'feedback: enabled\n' > "$WTBASE/.pas/config.yaml"
+cat > "$WTBASE/.pas/workspace/proc/inst-wt/status.yaml" <<'EOF'
+process: proc
+instance: inst-wt
+status: in_progress
+current_session: wt12abcd
+
+phases:
+  discovery:
+    status: completed
+EOF
+echo "ok" > "$WTBASE/.pas/workspace/proc/inst-wt/feedback/orchestrator-wt12abcd.md"
+( cd "$WTBASE" && git worktree add -q "$WTBASE/.wt-c06" -b c06-test-branch ) >/dev/null 2>&1
+
+if [ -d "$WTBASE/.wt-c06" ]; then
+  run_hook "verify-completion-gate.sh" \
+    "{\"cwd\":\"$WTBASE/.wt-c06\",\"stop_hook_active\":false,\"session_id\":\"wt12abcd\"}" \
+    0 "C06-3: worktree cwd resolves to main .pas/, finds feedback → exit 0"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C06-3: worktree fixture unavailable (skipped)\n"
+fi
+rm -rf "$WTBASE" "$C06DIR"
+
+# =========================================================================
+# Section: C08 — verify-task-completion phase output_files checkpoint
+# =========================================================================
+
+printf "\n${BOLD}C08. verify-task-completion output_files checkpoint${RESET}\n"
+
+C08DIR=$(mktemp -d)
+mkdir -p "$C08DIR/.pas/workspace/proc/inst-c08/feedback"
+mkdir -p "$C08DIR/.pas/workspace/proc/inst-c08/discovery"
+printf 'feedback: enabled\n' > "$C08DIR/.pas/config.yaml"
+
+# status.yaml uses the live key-based phase schema (matches cycle-14/status.yaml)
+cat > "$C08DIR/.pas/workspace/proc/inst-c08/status.yaml" <<'EOF'
+process: proc
+instance: inst-c08
+status: in_progress
+current_session: c08test1
+
+phases:
+  discovery:
+    status: in_progress
+    agent: framework-architect
+    output_files:
+      - discovery/priorities.md
+      - discovery/perspective.md
+  planning:
+    status: pending
+    agent: framework-architect
+    output_files:
+      - planning/implementation-plan.md
+  execution:
+    status: pending
+    output_files: []
+EOF
+
+# T-C08-1: phase deliverable missing → TaskCompleted blocked, exit 2
+run_hook "verify-task-completion.sh" \
+  "{\"cwd\":\"$C08DIR\",\"task_subject\":\"[PAS] Phase: discovery\",\"session_id\":\"c08test1\"}" \
+  2 "C08-1: missing output_files → exit 2 blocks task completion"
+
+assert_stderr_contains "phase deliverables missing" \
+  "C08-1: stderr names the failure mode"
+
+assert_stderr_contains "discovery/priorities.md" \
+  "C08-1: stderr lists the missing file"
+
+# T-C08-2: write the required files → TaskCompleted allowed
+echo "priorities content" > "$C08DIR/.pas/workspace/proc/inst-c08/discovery/priorities.md"
+echo "perspective content" > "$C08DIR/.pas/workspace/proc/inst-c08/discovery/perspective.md"
+
+run_hook "verify-task-completion.sh" \
+  "{\"cwd\":\"$C08DIR\",\"task_subject\":\"[PAS] Phase: discovery\",\"session_id\":\"c08test1\"}" \
+  0 "C08-2: all output_files present → exit 0"
+
+# T-C08-3: phase with empty output_files (no enforcement applies) → exit 0
+run_hook "verify-task-completion.sh" \
+  "{\"cwd\":\"$C08DIR\",\"task_subject\":\"[PAS] Phase: execution\",\"session_id\":\"c08test1\"}" \
+  0 "C08-3: phase with empty output_files → exit 0 (no-op)"
+
+# T-C08-4 (bonus): phase with no output_files block at all → exit 0
+cat > "$C08DIR/.pas/workspace/proc/inst-c08/status.yaml" <<'EOF'
+process: proc
+instance: inst-c08
+status: in_progress
+current_session: c08test1
+
+phases:
+  oldphase:
+    status: in_progress
+    agent: someagent
+EOF
+
+run_hook "verify-task-completion.sh" \
+  "{\"cwd\":\"$C08DIR\",\"task_subject\":\"[PAS] Phase: oldphase\",\"session_id\":\"c08test1\"}" \
+  0 "C08-4: phase with no output_files block → exit 0 (back-compat)"
+
+rm -rf "$C08DIR"
+
+# =========================================================================
 # Section: C04 — session-id-first workspace resolution
 # =========================================================================
 

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -712,6 +712,80 @@ fi
 rm -rf "$MIGDIR"
 
 # =========================================================================
+# Section: C02 — pas-session-start.sh tolerates missing fields (warns)
+# =========================================================================
+
+printf "\n${BOLD}C02. pas-session-start.sh missing-field tolerance${RESET}\n"
+
+# T-C02-1: status.yaml missing instance: → exit 0, warn names instance
+C02DIR=$(mktemp -d)
+mkdir -p "$C02DIR/.pas/workspace/proc/inst-1/feedback"
+printf 'feedback: enabled\n' > "$C02DIR/.pas/config.yaml"
+cat > "$C02DIR/.pas/workspace/proc/inst-1/status.yaml" <<'EOF'
+process: proc
+status: in_progress
+
+phases:
+  discovery:
+    status: pending
+EOF
+
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$C02DIR\",\"source\":\"startup\",\"session_id\":\"c02test1\"}" \
+  0 "C02-1: missing instance field → exit 0"
+
+assert_stdout_contains "Missing required fields: instance" \
+  "C02-1: stdout warns about missing instance field"
+
+# T-C02-2: status.yaml missing instance AND status — defaults applied
+C02DIR2=$(mktemp -d)
+mkdir -p "$C02DIR2/.pas/workspace/proc/inst-2/feedback"
+printf 'feedback: enabled\n' > "$C02DIR2/.pas/config.yaml"
+cat > "$C02DIR2/.pas/workspace/proc/inst-2/status.yaml" <<'EOF'
+process: proc
+
+phases:
+  discovery:
+    status: pending
+EOF
+
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$C02DIR2\",\"source\":\"startup\",\"session_id\":\"c02test2\"}" \
+  0 "C02-2: missing instance AND status → exit 0"
+
+assert_stdout_contains "inst-2 (status: unknown)" \
+  "C02-2: INSTANCE defaults to dirname, status to 'unknown'"
+
+# T-C02-3: complete status.yaml — no warning
+C02DIR3=$(mktemp -d)
+mkdir -p "$C02DIR3/.pas/workspace/proc/inst-3/feedback"
+printf 'feedback: enabled\n' > "$C02DIR3/.pas/config.yaml"
+cat > "$C02DIR3/.pas/workspace/proc/inst-3/status.yaml" <<'EOF'
+process: proc
+instance: inst-3
+status: in_progress
+
+phases:
+  discovery:
+    status: pending
+EOF
+
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$C02DIR3\",\"source\":\"startup\",\"session_id\":\"c02test3\"}" \
+  0 "C02-3: complete status.yaml → exit 0"
+
+if grep -q "Missing required fields" /tmp/test-hook-stdout 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C02-3: complete status.yaml should NOT trigger warning")
+  printf "  ${RED}FAIL${RESET} C02-3: warning printed for complete status.yaml\n"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C02-3: no warning for complete status.yaml\n"
+fi
+
+rm -rf "$C02DIR" "$C02DIR2" "$C02DIR3"
+
+# =========================================================================
 # Section: C01 — lib/guards.sh defensive defaults + resolve_pas_project_root
 # =========================================================================
 

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -460,7 +460,8 @@ run_hook "check-self-eval.sh" \
   "{\"cwd\":\"$TESTDIR\",\"agent_id\":\"test-agent\"}" \
   2 "check-self-eval: agent feedback missing → exit 2"
 
-assert_stderr_contains "SELF-EVALUATION MISSING" "check-self-eval: stderr shows missing message"
+assert_stderr_contains "shutting down without writing self-evaluation" "check-self-eval: stderr shows missing message"
+assert_stderr_contains "feedback: disabled" "check-self-eval: stderr documents opt-out path"
 
 # 6c: Feedback disabled → exit 0
 cat > "$TESTDIR/.pas/config.yaml" <<'EOF'
@@ -710,6 +711,59 @@ else
 fi
 
 rm -rf "$MIGDIR"
+
+# =========================================================================
+# Section: C03 — check-self-eval.sh grep -c integer comparison fix
+# =========================================================================
+
+printf "\n${BOLD}C03. check-self-eval.sh grep -c fix${RESET}\n"
+
+# Setup: enable feedback, in_progress workspace, feedback file present so the
+# transcript-secondary path is what's exercised — and feedback file ABSENT so
+# we hit the secondary path. We need a real transcript file with no signals.
+C03DIR=$(mktemp -d)
+mkdir -p "$C03DIR/.pas/workspace/proc/inst-c03/feedback"
+printf 'feedback: enabled\n' > "$C03DIR/.pas/config.yaml"
+cat > "$C03DIR/.pas/workspace/proc/inst-c03/status.yaml" <<'EOF'
+process: proc
+instance: inst-c03
+status: in_progress
+
+phases:
+  discovery:
+    status: completed
+EOF
+
+# T-C03-1: transcript with zero signal patterns → exits 2 cleanly (block,
+# but no integer-comparison crash). Pre-fix: would crash with `[: 0\n0:
+# integer expression expected` and exit 1, not 2.
+TRANSCRIPT_NO_SIGNALS=$(mktemp)
+printf 'just some text\nno signal markers here\nfinal line\n' > "$TRANSCRIPT_NO_SIGNALS"
+
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C03DIR\",\"agent_id\":\"unknown-agent\",\"agent_transcript_path\":\"$TRANSCRIPT_NO_SIGNALS\"}" \
+  2 "C03-1: zero-signal transcript → exit 2 cleanly (no integer-comparison crash)"
+
+if grep -q 'integer expression expected' /tmp/test-hook-stderr 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C03-1: integer comparison crash leaked into stderr")
+  printf "  ${RED}FAIL${RESET} C03-1: integer comparison crash present in stderr\n"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C03-1: no integer-comparison error in stderr\n"
+fi
+
+# T-C03-2: transcript WITH a signal pattern → exit 0 (signal detected via
+# secondary path). No agent_id-matching feedback file should be required.
+TRANSCRIPT_WITH_SIGNAL=$(mktemp)
+printf 'agent did some work\n[PPU-01]\nTarget: skill:foo\n' > "$TRANSCRIPT_WITH_SIGNAL"
+
+run_hook "check-self-eval.sh" \
+  "{\"cwd\":\"$C03DIR\",\"agent_id\":\"unknown-agent\",\"agent_transcript_path\":\"$TRANSCRIPT_WITH_SIGNAL\"}" \
+  0 "C03-2: transcript with PPU-01 signal → exit 0 (secondary path detects)"
+
+rm -f "$TRANSCRIPT_NO_SIGNALS" "$TRANSCRIPT_WITH_SIGNAL"
+rm -rf "$C03DIR"
 
 # =========================================================================
 # Section: C02 — pas-session-start.sh tolerates missing fields (warns)

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -807,6 +807,51 @@ run_hook "check-self-eval.sh" \
   "{\"cwd\":\"$C05DIR\",\"agent_id\":\"framework-architect\",\"agent_type\":\"framework-architect\",\"last_assistant_message\":\"$SHORT_MSG\"}" \
   2 "C05-8: summary-boilerplate response → exit 2 (block — that's the bug)"
 
+# T-C05-9 (C05.1 fixup): Agent-tool subagents inherit parent's SessionStart
+# context, not their own. The injected text MUST include a SUBAGENT NOTE
+# carve-out so subagents reading the parent's context know the lifecycle
+# does not apply to them — without this, Explore/Plan/general-purpose
+# subagents short-circuit into the PAS shutdown ritual (the residual #38
+# behavior caught in I2 validation).
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$C05DIR\",\"source\":\"startup\",\"session_id\":\"c05fixup\"}" \
+  0 "C05-9: orchestrator SessionStart exits 0 with SUBAGENT NOTE present"
+
+assert_stdout_contains "SUBAGENT NOTE" \
+  "C05-9: orchestrator's injected text includes SUBAGENT NOTE carve-out"
+
+assert_stdout_contains "spawned via the Agent tool" \
+  "C05-9: SUBAGENT NOTE explains who it applies to"
+
+assert_stdout_contains "DO NOT follow this lifecycle" \
+  "C05-9: SUBAGENT NOTE gives subagents an explicit opt-out"
+
+# T-C05-10 (C05.1 fixup): LAST_MSG with embedded newlines must not crash
+# the integer comparison. Pre-fix: `wc -c | tr -d ' '` could leave a
+# trailing newline in LAST_MSG_LEN; `[ "$X" -gt 200 ]` then crashed under
+# set -euo pipefail with "integer expression expected" — same family as
+# #55. The printf '%s' + tr '[:space:]' fix prevents the crash.
+LONG_MSG_WITH_NEWLINE=$(printf '%s\n%s\n%s' \
+  "Multi-line substantive response that the agent wrote as its actual report." \
+  "It includes embedded newlines because real subagent responses do." \
+  "Total length is comfortably over the 200-char threshold for the bypass.")
+
+# Use jq to safely encode the multi-line string into the JSON payload.
+LMSG_JSON=$(printf '%s' "$LONG_MSG_WITH_NEWLINE" | jq -Rs .)
+PAYLOAD="{\"cwd\":\"$C05DIR\",\"agent_id\":\"framework-architect\",\"agent_type\":\"framework-architect\",\"last_assistant_message\":${LMSG_JSON}}"
+
+run_hook "check-self-eval.sh" "$PAYLOAD" 0 \
+  "C05-10: LAST_MSG with newlines → exit 0 cleanly (no integer-expression crash)"
+
+if grep -qE 'integer expression expected' /tmp/test-hook-stderr 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C05-10: integer expression crash leaked into stderr")
+  printf "  ${RED}FAIL${RESET} C05-10: integer expression crash present in stderr\n"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C05-10: no integer-expression error in stderr\n"
+fi
+
 rm -rf "$C05DIR"
 
 # =========================================================================

--- a/plugins/pas/hooks/verify-completion-gate.sh
+++ b/plugins/pas/hooks/verify-completion-gate.sh
@@ -80,20 +80,30 @@ if [ "$ORCHESTRATOR_OK" = true ] && [ -z "$MISSING_AGENTS" ]; then
   exit 0
 fi
 
-# BLOCK: build failure message
+# BLOCK: build failure message.
+# Print absolute paths so a worktree-cwd session sees the same path the hook
+# actually checked. We reuse $FEEDBACK_DIR as resolved by guard_active_workspace
+# (post-C01 this is anchored to PAS_PROJECT_ROOT, so it's already absolute);
+# pwd-resolve once for safety against any caller that passes a relative path.
+ABS_FEEDBACK_DIR=$(cd "$FEEDBACK_DIR" 2>/dev/null && pwd || echo "$FEEDBACK_DIR")
+ABS_EXPECTED="${ABS_FEEDBACK_DIR}/${EXPECTED_FILE}"
+
 {
   echo "COMPLETION GATE FAILED"
   echo ""
+  echo "Resolved PAS_PROJECT_ROOT: ${PAS_PROJECT_ROOT:-<unset>}"
+  echo "Checked feedback dir:      ${ABS_FEEDBACK_DIR}"
+  echo ""
   if [ "$ORCHESTRATOR_OK" != true ]; then
-    echo "Orchestrator self-evaluation missing: ${FEEDBACK_DIR}/${EXPECTED_FILE}"
+    echo "Orchestrator self-evaluation missing: ${ABS_EXPECTED}"
   fi
   if [ -n "$MISSING_AGENTS" ]; then
     echo "Agent self-evaluation missing for: ${MISSING_AGENTS}"
-    echo "Each agent must write feedback to ${FEEDBACK_DIR}/{agent-name}.md before shutdown."
+    echo "Each agent must write feedback to ${ABS_FEEDBACK_DIR}/{agent-name}.md before shutdown."
   fi
   echo ""
   echo "Before stopping, you MUST:"
-  echo "1. Write self-evaluation to ${FEEDBACK_DIR}/${EXPECTED_FILE}"
+  echo "1. Write self-evaluation to ${ABS_EXPECTED}"
   echo "   - Use .pas/library/self-evaluation/SKILL.md for the format"
   echo "   - If nothing went wrong, write \"No issues detected.\""
   if [ -n "$MISSING_AGENTS" ]; then
@@ -106,5 +116,9 @@ fi
   fi
   echo ""
   echo "You cannot stop until these steps are done."
+  echo ""
+  echo "If your cwd differs from PAS_PROJECT_ROOT (e.g. running inside a git"
+  echo "worktree), write the file at the absolute path above — the hook"
+  echo "always checks that exact path."
 } >&2
 exit 2

--- a/plugins/pas/hooks/verify-task-completion.sh
+++ b/plugins/pas/hooks/verify-task-completion.sh
@@ -76,6 +76,56 @@ EOF
       exit 2
     fi
     ;;
+
+  *"Phase: "*)
+    # Phase deliverable enforcement (#49). status.yaml schema is key-based:
+    #   phases:
+    #     <phase-name>:
+    #       output_files:
+    #         - path/relative/to/workspace
+    # Find the phase block, then extract output_files entries until the next
+    # field at the same indent level. Phase with no output_files block → no-op.
+    PHASE_NAME=$(echo "$TASK_SUBJECT" | sed 's/^\[PAS\] Phase: //')
+
+    OUTPUT_FILES=$(awk -v phase="$PHASE_NAME" '
+      # Detect the start of the named phase: "  <phase>:" at exactly 2-space indent
+      $0 ~ "^  " phase ":[[:space:]]*$" { in_phase=1; next }
+      # Inside phase: detect a sibling phase or top-level field — exit
+      in_phase && /^[a-zA-Z_]/ { in_phase=0; in_outputs=0 }
+      in_phase && /^  [a-zA-Z_]/ { in_phase=0; in_outputs=0 }
+      # Inside phase: detect output_files: header
+      in_phase && /^    output_files:/ { in_outputs=1; next }
+      # Once inside output_files, capture "      - path" entries
+      in_outputs && /^      - / { sub(/^      - /, ""); print; next }
+      # Anything else inside phase ends the output_files capture
+      in_outputs && !/^      - / { in_outputs=0 }
+    ' "$ACTIVE_STATUS")
+
+    if [ -n "$OUTPUT_FILES" ]; then
+      MISSING=""
+      while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        # Strip surrounding quotes if any
+        path=$(echo "$path" | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
+        if [ ! -e "$ACTIVE_WORKSPACE/$path" ]; then
+          MISSING="${MISSING:+$MISSING, }$path"
+        fi
+      done <<< "$OUTPUT_FILES"
+
+      if [ -n "$MISSING" ]; then
+        cat >&2 <<EOF
+Cannot complete "${TASK_SUBJECT}": phase deliverables missing.
+  Workspace: ${ACTIVE_WORKSPACE}
+  Missing output_files: ${MISSING}
+
+Each path under the phase's output_files: list in status.yaml must exist
+on disk before this task can be marked complete. See:
+  library/orchestration/lifecycle.md (phase output_files contract)
+EOF
+        exit 2
+      fi
+    fi
+    ;;
 esac
 
 # All checks passed (or task type not enforced)

--- a/plugins/pas/library/orchestration/lifecycle.md
+++ b/plugins/pas/library/orchestration/lifecycle.md
@@ -98,7 +98,7 @@ Sub-processes write their own status.yaml. Parent references via `subprocess: {p
 
 When all phases are complete:
 
-1. **Verify all output files** exist for all phases
+1. **Verify all output files** exist for all phases. The `verify-task-completion.sh` TaskCompleted hook now enforces this at phase boundaries: completing a `[PAS] Phase: <name>` task is blocked when any path under that phase's `output_files:` list is missing on disk. A phase with no `output_files:` block is unaffected. (Closes #49.)
 2. **Send downstream feedback** to each team member (if any): share relevant quality notes from later phases
 3. **Each agent writes self-evaluation** using `.pas/library/self-evaluation/SKILL.md` (when feedback is enabled). This is mandatory -- do NOT proceed to step 4 until all agents have written their feedback. Output to `.pas/workspace/{process}/{slug}/feedback/{agent-name}.md`. The `check-self-eval.sh` SubagentStop hook blocks agents from stopping without feedback, and the `verify-completion-gate.sh` Stop hook verifies ALL agents have feedback files before the orchestrator can stop.
 4. **All agents shut down together** after self-evaluation completes. The orchestrator MUST NOT instruct agents to skip self-evaluation — hook enforcement will block the session if any agent feedback is missing.

--- a/plugins/pas/pas-config.yaml
+++ b/plugins/pas/pas-config.yaml
@@ -1,2 +1,7 @@
 feedback: enabled
 feedback_disabled_at: ~
+
+# Where framework:pas signals get filed when routed via Route: github-issue.
+# This MUST point at the PAS plugin's own repo — never the host project's
+# repo. Enforced by route-feedback.sh; if absent, the hook refuses to file.
+framework_signal_repo: ZoranSpirkovski/PAS

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md
@@ -33,12 +33,12 @@ If untargeted: recommend where to start based on signal volume and severity.
 
 ### 3. Ask User Preference
 
-Before applying any changes, ask:
+Use the AskUserQuestion tool to present these options. Do not ask in plain text — the structured prompt makes the choice unambiguous and the user's response routable. Options:
 
-- **Apply all + remember**: apply all signals for this artifact, remember this preference for future sessions
-- **Apply all once**: apply all signals for this artifact this time only
-- **Just this**: let me pick which signals to apply one at a time
-- **Review first**: show me each signal before deciding
+1. **Apply all + remember** — apply all signals for this artifact, remember this preference for future sessions
+2. **Apply all once** — apply all signals for this artifact this time only
+3. **Just this** — let me pick which signals to apply one at a time
+4. **Review first** — show me each signal before deciding
 
 ### 4. Sanity Checks
 
@@ -117,6 +117,16 @@ Change: {what was actually changed in the artifact}
 - Remove processed signals from `feedback/backlog/`
 - Stage modified artifact and changelog
 - Commit with message: `"Apply feedback: {artifact-path} — {brief description}"`
+
+### 13. Where Do Changes Go?
+
+Two routes exist; the wrong route will file PAS-internal changes onto the user's product repo. Always:
+
+- **PAS plugin / process / agent / skill artifacts** (under `plugins/pas/`, `.pas/processes/`, `.pas/library/`) — apply edits in-repo as direct file changes. No GitHub issue.
+- **`framework:pas` signals routed to GitHub** — filed ONLY on the PAS framework repo (`ZoranSpirkovski/PAS`, enforced by `route-feedback.sh` `framework_signal_repo`). Never on the host project's repo. The hook handles this; this skill does not call `gh issue create`.
+- **Process / agent / skill signals** — stay local in the artifact's `feedback/backlog/` until an `applying-feedback` session processes them. They NEVER become GitHub issues anywhere.
+
+If you are about to call `gh issue create` from this skill, stop. The hook routes framework signals; this skill applies signals — it does not file them.
 
 ## Quality Tests
 

--- a/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/changelog.md
+++ b/plugins/pas/processes/pas/agents/orchestrator/skills/applying-feedback/changelog.md
@@ -1,1 +1,7 @@
 # Applying Feedback Skill Changelog
+
+## 2026-04-16 — AskUserQuestion + routing-rule clarification
+
+Triggered by: cycle-14 hoist of #30, #40 (AskUserQuestion); #41 (routing rule)
+Pattern: agent re-asked options in plain text after explicit preference; agent filed framework signal on user product repo
+Change: Step 3 mandates AskUserQuestion with the four labeled options; new Step 13 codifies routing rules to prevent product-repo contamination


### PR DESCRIPTION
## Summary

Milestone 3 of the 44-issue triage roadmap. Closes 18 implementation issues + 6 close-on-merge dups/umbrellas at the hook layer. One residual deferred to cycle 15 (text leak — see Known Residual below).

- `lib/guards.sh`: defensive default for `CLAUDE_PLUGIN_ROOT`; new `resolve_pas_project_root` (cwd → `.pas/config.yaml` walk → `git rev-parse --show-toplevel`); new `safe_grep_field`; new `guard_agent_in_active_process`; `guard_active_workspace` anchored to `$PAS_PROJECT_ROOT` (closes #64, #97, #98)
- `pas-session-start.sh`: tolerate missing `instance:` / `status:` / `process:` fields; print `MISSING_FIELDS` warning instead of silently degrading; skip lifecycle injection when `agent_id` is non-empty (closes #54, #58, partial #38, partial #68)
- `check-self-eval.sh`: fix `grep -c || echo 0` integer-comparison crash; gate on `guard_agent_in_active_process` so non-PAS subagents pass through silently; preserve substantive `last_assistant_message` (>200 chars, no summary keyword) instead of blocking with elided summary; SUBAGENT NOTE carve-out + `tr -d '[:space:]'` for `LAST_MSG_LEN` (closes #55, #71, #103, partial #38, partial #67, partial #68)
- `lib/workspace.sh`: session-id-first resolution in `find_active_workspace_status` — match `current_session:` field before falling back to mtime (closes #52)
- `verify-completion-gate.sh`: absolute paths in failure diagnostics; `Resolved PAS_PROJECT_ROOT:` line; closes the worktree deadlock (closes #100)
- `verify-task-completion.sh`: new `[PAS] Phase: <name>` matcher reads `output_files` from status.yaml and blocks completion when files are missing (closes #49)
- `route-feedback.sh`: read repo from new `framework_signal_repo:` config key (defaults to `ZoranSpirkovski/PAS`); refuse to file when target is empty; audit log entry written to `framework-routing.log` before every `gh issue create` (closes #59)
- `pas-config.yaml`: add `framework_signal_repo: ZoranSpirkovski/PAS`
- `processes/pas/agents/orchestrator/skills/applying-feedback/SKILL.md`: Step 3 mandates `AskUserQuestion` with four labeled options; new Step 13 codifies routing rules (in-repo edits vs framework GitHub issues vs local backlog) (closes #30, #40, #41)
- `tests/test-hooks.sh`: 30 new tests across the 8 affected scripts; harness now 112 tests / 0 fail (well above the cycle gate of ≥90)
- `plugin.json`, `marketplace.json`: version bumped 1.3.2 → 1.3.3
- `plugins/pas/hooks/changelog.md`: new file documenting the cycle-14 changeset

Closes via cycle 14 fixes (constituent or admin):
- #31, #33 — duplicates of #32
- #61 — duplicate of #62
- #66 — duplicate of #65
- #56, #57 — umbrella signals resolved by #54 + #55 + #64

Closes #70 sub-issues filed during release: #97, #98, #100, #103. (#99, #101, #102, #104 deferred to M5/M7 per cycle-14 discovery consensus.)

## Known Residual (deferred to cycle 15)

**SessionStart text leak into Agent-tool subagent context** — tracked as #109.

Hook-layer enforcement for #38, #67, #68 is correct: `check-self-eval.sh` does not block non-PAS subagents, and the rogue feedback file these subagents may write is benign (no gate enforces it). However, the SessionStart lifecycle heredoc still reaches Agent-tool subagent contexts despite C05's `agent_id` skip and C05.1's SUBAGENT NOTE carve-out. Live dogfood test in cycle 14 (validation §I2 addendum) reproduced the leak twice — root-cause hypothesis is that Claude Code's SessionStart payload may not populate `agent_id` for Agent-tool subagents. Cycle 15 will verify the payload shape and pick the correct skip signal.

**This means #38, #67, #68 are partially closed** at the hook layer. The text-leak follow-up is tracked in #109.

## Test plan

- [x] `bash plugins/pas/hooks/tests/test-hooks.sh` — 112/112 pass (target ≥ 90 from validation gate G1)
- [x] No unguarded `CLAUDE_PLUGIN_ROOT` (gate G2 — verified by qa-engineer)
- [x] No `$CWD/.pas` in hook source (gate G3 — verified by qa-engineer)
- [x] Plugin version 1.3.3 in both `plugin.json` and `marketplace.json` (gate G4)
- [x] `hooks/changelog.md` cycle 14 entry present (gate G5)
- [ ] **Reviewer:** spot-check that `git diff main...HEAD --stat` lists only `plugins/pas/` and `.claude-plugin/` files (verified pre-push by community-manager)
- [ ] **Post-merge cycle 15:** repro the SessionStart text leak from a fresh session and validate any deeper SessionStart fix (#109)

## References

- Validation report: `.pas/workspace/pas-development/cycle-14/validation/report.md`
- Discovery priorities: `.pas/workspace/pas-development/cycle-14/discovery/priorities.md`
- Changelog: `plugins/pas/hooks/changelog.md`