### PR TITLE
Cycle 16: Fix hook concurrency cluster (#173, #174, #162, #160, #156, #155)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "PAS (Process, Agent, Skill) framework for building agentic workflows",
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   "plugins": [
     {
       "name": "pas",
       "source": "./plugins/pas",
       "description": "Framework for building agentic workflows with composable processes, agents, and skills. Provides /pas command to create and manage automated pipelines.",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "author": {
         "name": "Zoran Spirkovski"
       },

--- a/plugins/pas/.claude-plugin/plugin.json
+++ b/plugins/pas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pas",
   "description": "Process-Agent-Skill framework for building agentic workflows. Create automated pipelines with composable processes, agents, and skills that improve through feedback.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Zoran Spirkovski"
   },

--- a/plugins/pas/hooks/changelog.md
+++ b/plugins/pas/hooks/changelog.md
@@ -1,5 +1,19 @@
 # Hooks Changelog
 
+## 2026-04-28 — Cycle 16 / 1.4.1: Hook Substrate Concurrency Cluster
+
+Triggered by issue cluster #173, #174, #162, #160, #156, #155 — all rooted in the same substrate race: hooks misroute to the wrong workspace under concurrent worktree/session runs. Five surgical fixes; harness 130 → 142 (+8 new C16 tests, +4 reframed session-start tests).
+
+**lib/workspace.sh** — `find_active_workspace_status` Pass 0 broadened to match either `current_session:` or `session_id:` field (#155). Backwards compatible; processes that already use the canonical field continue to match.
+
+**pas-session-start.sh** — fresh sessions no longer auto-bind to in-progress workspaces (#173, #156 issue 2). The hook now only refreshes `current_session:` when the session id is already in the workspace's `sessions:` list (true reconnect). Skills bind explicitly when they create or claim a workspace — see Session Binding Contract in `library/orchestration/lifecycle.md`. Display block updated: bound sessions see a "reconnect" message, fresh-but-unbound sessions see a "detected but not bound" message preceded by parseable `PAS_WORKSPACE_MISMATCH=<slug>` and `PAS_WORKSPACE_MISMATCH_PATH=<path>` lines (#174) so downstream skills/hooks can hard-gate without parsing English.
+
+**route-feedback.sh** — two CWD-anchoring bugs fixed (#156 issues 1 & 3). Warnings.log now anchors to `PAS_PROJECT_ROOT` instead of `$CWD` (eliminates recursive `.pas/.pas/feedback/` paths when subagent CWD is under `.pas/workspace/<X>/`). Tier 3 process/agent/skill resolution also uses `PAS_PROJECT_ROOT`, fixing silent "Unknown target" drops when subagents run from non-root CWDs.
+
+**verify-completion-gate.sh** — early sanity check (#162, #160). When `SESSION_ID` is provided AND the resolver-returned workspace's binding field does NOT match this session id (i.e., resolver fell through to mtime fallback), warn to stderr and `exit 0` instead of demanding feedback at a sibling worktree's path. The owning session's gate still fires when that session stops; this only prevents cross-session misroutes.
+
+**Doctrine:** N/N+1 protocol applies to this cycle. Static + harness validation in 16; live multi-worktree behavior validation deferred to cycle 17 from a fresh session.
+
 ## 2026-04-20 — Cycle 15 / Milestone 4: Marketplace-Authoritative
 
 Triggered by: issue #125 — PAS becomes a tool for maintaining user-controlled marketplaces of skills. Consumer projects hold only workspace state; skill definitions live in the marketplace; feedback flows back to the marketplace.

--- a/plugins/pas/hooks/lib/workspace.sh
+++ b/plugins/pas/hooks/lib/workspace.sh
@@ -18,11 +18,15 @@ find_active_workspace_status() {
 
   local result=""
 
-  # Pass 0: when a session id is provided, find the workspace whose
-  # current_session matches. Wins over mtime/in_progress passes.
+  # Pass 0: when a session id is provided, find the workspace whose binding
+  # field matches. Matches either `current_session:` (PAS canonical) or
+  # `session_id:` (the natural field name many process docs reach for —
+  # e.g. v2-agency-delivery). Wins over mtime/in_progress passes.
+  # Cross-field matching (#155) closes the multi-worktree mtime-misroute
+  # bug for processes that don't use the canonical field name.
   if [ -n "$session_id" ]; then
     result=$(find "$workspace_dir" -name "status.yaml" -print 2>/dev/null | while read -r f; do
-      if grep -q "^current_session:[[:space:]]*${session_id}\b" "$f" 2>/dev/null; then
+      if grep -qE "^(current_session|session_id):[[:space:]]*${session_id}\b" "$f" 2>/dev/null; then
         echo "$f"
         break
       fi

--- a/plugins/pas/hooks/pas-session-start.sh
+++ b/plugins/pas/hooks/pas-session-start.sh
@@ -39,29 +39,29 @@ if guard_active_workspace "$SCRIPT_DIR"; then
   true
 fi
 
-# Record session in status.yaml (if active workspace exists)
+# Record session in status.yaml ONLY for true reconnects.
+#
+# Concurrency fix (#173, #156 issue 2): previously this block auto-bound any
+# fresh session to whichever in_progress workspace had the most recent mtime
+# (via Pass 1 of find_active_workspace_status). With multiple concurrent
+# worktrees, every new session would clobber `current_session:` on the wrong
+# workspace and the stop gate would later demand feedback from sessions that
+# never touched the work. A fresh session must NOT auto-bind — skills (e.g.
+# `/v2-agency-delivery`) bind explicitly when they create or claim a workspace,
+# per the Session Binding Contract in library/orchestration/lifecycle.md.
+#
+# True-reconnect detection: this session id is already in the workspace's
+# `sessions:` list. In that case, refresh `current_session:` so the Stop gate
+# keeps tracking the live session. Otherwise leave the workspace untouched.
+SESSION_BOUND=false
 if [ -n "$ACTIVE_STATUS" ] && [ -n "$SESSION_SHORT" ]; then
-  TIMESTAMP=$(date -Iseconds)
-
-  # Write current_session marker
-  if grep -q '^current_session:' "$ACTIVE_STATUS" 2>/dev/null; then
-    sed -i "s/^current_session:.*/current_session: ${SESSION_SHORT}/" "$ACTIVE_STATUS"
-  else
-    echo "current_session: ${SESSION_SHORT}" >> "$ACTIVE_STATUS"
-  fi
-
-  # Append to sessions list if not already recorded
-  if ! grep -q "id: ${SESSION_SHORT}" "$ACTIVE_STATUS" 2>/dev/null; then
-    if ! grep -q '^sessions:' "$ACTIVE_STATUS" 2>/dev/null; then
-      echo "" >> "$ACTIVE_STATUS"
-      echo "sessions:" >> "$ACTIVE_STATUS"
+  if grep -q "id: ${SESSION_SHORT}" "$ACTIVE_STATUS" 2>/dev/null; then
+    SESSION_BOUND=true
+    if grep -q '^current_session:' "$ACTIVE_STATUS" 2>/dev/null; then
+      sed -i "s/^current_session:.*/current_session: ${SESSION_SHORT}/" "$ACTIVE_STATUS"
+    else
+      echo "current_session: ${SESSION_SHORT}" >> "$ACTIVE_STATUS"
     fi
-    cat >> "$ACTIVE_STATUS" <<EOF
-  - id: ${SESSION_SHORT}
-    started_at: ${TIMESTAMP}
-    completed_at: ~
-    feedback_collected: false
-EOF
   fi
 fi
 
@@ -141,11 +141,25 @@ if [ -n "$ACTIVE_STATUS" ]; then
     echo "  Continuing with derived values — fix status.yaml to silence this warning."
     echo ""
   fi
-  echo "Active workspace: ${PROCESS_NAME}/${INSTANCE} (status: ${TOP_STATUS})"
-  echo "Path: ${ACTIVE_WORKSPACE}"
-
-  if [ "$TOP_STATUS" = "in_progress" ]; then
-    echo "This session may be a continuation. Read status.yaml to determine where to resume."
+  if [ "$SESSION_BOUND" = "true" ]; then
+    echo "Active workspace: ${PROCESS_NAME}/${INSTANCE} (status: ${TOP_STATUS})"
+    echo "Path: ${ACTIVE_WORKSPACE}"
+    if [ "$TOP_STATUS" = "in_progress" ]; then
+      echo "This session is a reconnect. Read status.yaml to determine where to resume."
+    fi
+  elif [ "$TOP_STATUS" = "in_progress" ]; then
+    # Fresh session, but an in_progress workspace exists. Emit a parseable
+    # signal (#174) so downstream skills/hooks can hard-gate on the mismatch
+    # without parsing English. The plain-language warning follows for humans.
+    echo "PAS_WORKSPACE_MISMATCH=${INSTANCE}"
+    echo "PAS_WORKSPACE_MISMATCH_PATH=${ACTIVE_WORKSPACE}"
+    echo "Detected in-progress workspace at ${ACTIVE_WORKSPACE}"
+    echo "  Process: ${PROCESS_NAME}/${INSTANCE}"
+    echo "  This session is NOT bound to it. To resume, invoke the matching"
+    echo "  skill (e.g. /v2-agency-delivery <slug>) which will re-bind."
+  else
+    echo "Active workspace: ${PROCESS_NAME}/${INSTANCE} (status: ${TOP_STATUS})"
+    echo "Path: ${ACTIVE_WORKSPACE}"
   fi
 fi
 

--- a/plugins/pas/hooks/route-feedback.sh
+++ b/plugins/pas/hooks/route-feedback.sh
@@ -77,19 +77,22 @@ resolve_target_path() {
   # Tier 3: consumer-local .pas/processes tree (legacy; transitional
   # backward-compat for consumers/cycles that still carry process copies).
   # Removed in a future cycle once downstream has migrated.
+  # Anchor to PAS_PROJECT_ROOT (not CWD) so subagent CWDs under .pas/workspace/
+  # don't silently drop signals to "Unknown target" (#156 issue 3).
+  local tier3_root="${PAS_PROJECT_ROOT:-$CWD}"
   case "$type" in
     process)
-      if [ -d "$CWD/$PAS_ROOT/processes/$value/feedback/backlog" ]; then
-        found="$CWD/$PAS_ROOT/processes/$value/feedback/backlog"
+      if [ -d "$tier3_root/$PAS_ROOT/processes/$value/feedback/backlog" ]; then
+        found="$tier3_root/$PAS_ROOT/processes/$value/feedback/backlog"
       fi
       ;;
     agent)
-      found=$(find "$CWD/$PAS_ROOT/processes" -path "*/agents/$value/feedback/backlog" -type d 2>/dev/null | head -1)
+      found=$(find "$tier3_root/$PAS_ROOT/processes" -path "*/agents/$value/feedback/backlog" -type d 2>/dev/null | head -1)
       ;;
     skill)
-      found=$(find "$CWD/$PAS_ROOT/processes" -path "*/skills/$value/feedback/backlog" -type d 2>/dev/null | head -1)
+      found=$(find "$tier3_root/$PAS_ROOT/processes" -path "*/skills/$value/feedback/backlog" -type d 2>/dev/null | head -1)
       if [ -z "$found" ]; then
-        found=$(find "$CWD/$PAS_ROOT/library" -path "*/$value/feedback/backlog" -type d 2>/dev/null | head -1)
+        found=$(find "$tier3_root/$PAS_ROOT/library" -path "*/$value/feedback/backlog" -type d 2>/dev/null | head -1)
       fi
       ;;
   esac
@@ -256,8 +259,12 @@ parse_and_route_signals() {
         elif [ -n "$target_path" ]; then
           route_signal "$current_signal" "$current_id" "$source_name" "$target_path"
         else
-          mkdir -p "$CWD/$PAS_ROOT/feedback"
-          echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$CWD/$PAS_ROOT/feedback/warnings.log" 2>/dev/null || true
+          # Anchor warnings.log to PAS_PROJECT_ROOT (not CWD) so subagent CWDs
+          # under .pas/workspace/<X>/ don't create recursive .pas/.pas/ paths
+          # (#156 issue 1).
+          local warn_root="${PAS_PROJECT_ROOT:-$CWD}"
+          mkdir -p "$warn_root/$PAS_ROOT/feedback"
+          echo "[$(date -Iseconds)] WARNING: Unknown target '$current_target'" >> "$warn_root/$PAS_ROOT/feedback/warnings.log" 2>/dev/null || true
         fi
       fi
 

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -251,11 +251,47 @@ assert_stdout_contains "feedback: enabled" "session-start: outputs feedback stat
 assert_stdout_contains "CREATION ROUTING" "session-start: outputs creation routing instruction"
 assert_stdout_contains "DEVELOPMENT ROUTING" "session-start: outputs development routing instruction"
 
-assert_file_contains "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" \
-  "current_session: abc12345" "session-start: writes current_session to status.yaml"
+# NEW (cycle 16, #173): fresh sessions must NOT auto-bind to an existing
+# in_progress workspace. The status.yaml from setup has no `id: abc12345` in
+# its sessions list, so this session is fresh and the hook must leave the
+# workspace untouched. Skills bind explicitly when they create or claim a
+# workspace (Session Binding Contract, library/orchestration/lifecycle.md).
+if grep -q '^current_session:' "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("session-start (#173): fresh session auto-bound — current_session: was written")
+  printf "  ${RED}FAIL${RESET} session-start: fresh session auto-bound (regression of #173)\n"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} session-start: fresh session does NOT auto-bind (#173)\n"
+fi
+if grep -q "id: abc12345" "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("session-start (#173): fresh session appended to sessions list")
+  printf "  ${RED}FAIL${RESET} session-start: fresh session appended to sessions list (regression of #173)\n"
+else
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} session-start: fresh session not appended to sessions list (#173)\n"
+fi
+assert_stdout_contains "PAS_WORKSPACE_MISMATCH=cycle-1" \
+  "session-start (#174): emits parseable PAS_WORKSPACE_MISMATCH= for unbound in_progress workspace"
+assert_stdout_contains "PAS_WORKSPACE_MISMATCH_PATH=" \
+  "session-start (#174): emits parseable PAS_WORKSPACE_MISMATCH_PATH="
 
+# Reconnect path: pre-seed the session id into the workspace's sessions list,
+# then re-run session-start and assert that current_session: IS now refreshed.
+cat >> "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" <<EOF
+
+sessions:
+  - id: abc12345
+    started_at: 2026-03-10T10:00:00+00:00
+    completed_at: ~
+    feedback_collected: false
+EOF
+run_hook "pas-session-start.sh" \
+  "{\"cwd\":\"$TESTDIR\",\"source\":\"resume\",\"session_id\":\"abc12345xyz\"}" \
+  0 "session-start (#173): reconnect runs cleanly"
 assert_file_contains "$TESTDIR/.pas/workspace/test/cycle-1/status.yaml" \
-  "id: abc12345" "session-start: appends session to sessions list"
+  "current_session: abc12345" "session-start: reconnect refreshes current_session"
 
 # =========================================================================
 # Section 4: verify-completion-gate.sh
@@ -1681,6 +1717,241 @@ else
   printf "  ${GREEN}PASS${RESET} C12-4: resolve_origin_marketplace fails cleanly without registry\n"
 fi
 rm -rf "$FAKE_HOME"
+
+# =========================================================================
+# Section C16: Hook substrate concurrency cluster
+# (#155, #156, #162, #173, #174 — see plugins/pas/hooks/changelog.md 1.4.1)
+# =========================================================================
+printf "\n${BOLD}13. C16 — concurrency cluster${RESET}\n"
+
+# T-C16-1a: workspace.sh Pass 0 matches `current_session:` (regression for #155 fix)
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/inst-cs/feedback"
+cat > "$C16DIR/.pas/workspace/proc/inst-cs/status.yaml" <<'EOF'
+process: proc
+instance: inst-cs
+status: in_progress
+current_session: deadbeef
+EOF
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$C16DIR/.pas/workspace' 'deadbeef'")
+if echo "$RESULT" | grep -q "inst-cs/status.yaml"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-1a: Pass 0 matches current_session: field (regression)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-1a: current_session: match failed (got: $RESULT)")
+  printf "  ${RED}FAIL${RESET} C16-1a (got: %s)\n" "$RESULT"
+fi
+rm -rf "$C16DIR"
+
+# T-C16-1b: workspace.sh Pass 0 matches `session_id:` field (#155 fix)
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/inst-sid/feedback"
+cat > "$C16DIR/.pas/workspace/proc/inst-sid/status.yaml" <<'EOF'
+process: proc
+instance: inst-sid
+status: in_progress
+session_id: cafebabe
+EOF
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$C16DIR/.pas/workspace' 'cafebabe'")
+if echo "$RESULT" | grep -q "inst-sid/status.yaml"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-1b: Pass 0 matches session_id: field (#155)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-1b: session_id: match failed (got: $RESULT)")
+  printf "  ${RED}FAIL${RESET} C16-1b (got: %s)\n" "$RESULT"
+fi
+rm -rf "$C16DIR"
+
+# T-C16-1c: with neither field set, falls through to mtime (regression)
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/inst-noid/feedback"
+cat > "$C16DIR/.pas/workspace/proc/inst-noid/status.yaml" <<'EOF'
+process: proc
+instance: inst-noid
+status: in_progress
+EOF
+RESULT=$(bash -c "source '$HOOKS_DIR/lib/workspace.sh'; find_active_workspace_status '$C16DIR/.pas/workspace' 'nomatch1'")
+if echo "$RESULT" | grep -q "inst-noid/status.yaml"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-1c: falls through to Pass 1 when no field matches\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-1c: Pass 1 fallback failed (got: $RESULT)")
+  printf "  ${RED}FAIL${RESET} C16-1c (got: %s)\n" "$RESULT"
+fi
+rm -rf "$C16DIR"
+
+# T-C16-2a: route-feedback warnings.log anchors to PAS_PROJECT_ROOT, not CWD
+# When CWD is under .pas/workspace/<X>/, the old code created
+# .pas/workspace/<X>/.pas/feedback/warnings.log (recursive). New code uses
+# PAS_PROJECT_ROOT.
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/inst-cwd/feedback"
+mkdir -p "$C16DIR/.pas/processes/proc/feedback/backlog"
+cat > "$C16DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+cat > "$C16DIR/.pas/workspace/proc/inst-cwd/status.yaml" <<'EOF'
+process: proc
+instance: inst-cwd
+status: in_progress
+current_session: cwdtest1
+EOF
+# Write a feedback file with an UNKNOWN target so we trigger the warnings.log path
+cat > "$C16DIR/.pas/workspace/proc/inst-cwd/feedback/orchestrator-cwdtest1.md" <<'EOF'
+[OQI-99]
+Target: bogus:nothing
+Degraded: warnings-log smoke test
+Priority: LOW
+EOF
+# Run hook with CWD set to PROJECT ROOT (this is what Claude Code passes); the
+# bug manifested because route-feedback used $CWD literally even when guards
+# resolved PAS_PROJECT_ROOT correctly.
+echo "{\"cwd\":\"$C16DIR\",\"session_id\":\"cwdtest1xyz\"}" | bash "$HOOKS_DIR/route-feedback.sh" >/dev/null 2>&1 || true
+if [ -f "$C16DIR/.pas/feedback/warnings.log" ] && [ ! -d "$C16DIR/.pas/workspace/proc/inst-cwd/.pas" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-2a: warnings.log anchors to PAS_PROJECT_ROOT (#156)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-2a: warnings.log not at expected path or recursive .pas/.pas/ created")
+  printf "  ${RED}FAIL${RESET} C16-2a — log: $(ls $C16DIR/.pas/feedback/ 2>&1 | head -3) ; recursive: $(find $C16DIR -name '.pas' -type d 2>/dev/null | wc -l)\n"
+fi
+rm -rf "$C16DIR"
+
+# T-C16-2b: Tier 3 process resolution uses PAS_PROJECT_ROOT (#156 issue 3)
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/inst-tier3/feedback"
+mkdir -p "$C16DIR/.pas/processes/local-process/feedback/backlog"
+cat > "$C16DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+cat > "$C16DIR/.pas/workspace/proc/inst-tier3/status.yaml" <<'EOF'
+process: proc
+instance: inst-tier3
+status: in_progress
+current_session: tier3xyz
+EOF
+cat > "$C16DIR/.pas/workspace/proc/inst-tier3/feedback/orchestrator-tier3xyz.md" <<'EOF'
+[OQI-77]
+Target: process:local-process
+Degraded: tier3 smoke test
+Priority: LOW
+EOF
+echo "{\"cwd\":\"$C16DIR\",\"session_id\":\"tier3xyzfull\"}" | bash "$HOOKS_DIR/route-feedback.sh" >/dev/null 2>&1 || true
+ROUTED=$(find "$C16DIR/.pas/processes/local-process/feedback/backlog" -type f 2>/dev/null | head -1)
+if [ -n "$ROUTED" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-2b: Tier 3 anchors to PAS_PROJECT_ROOT (#156)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-2b: Tier 3 routing did not land in backlog")
+  printf "  ${RED}FAIL${RESET} C16-2b: signal not routed to local process backlog\n"
+fi
+rm -rf "$C16DIR"
+
+# T-C16-3: SessionStart with two in_progress workspaces + fresh id leaves
+# both untouched (no auto-bind). Belt-and-suspenders for #173.
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/A/feedback"
+mkdir -p "$C16DIR/.pas/workspace/proc/B/feedback"
+cat > "$C16DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+cat > "$C16DIR/.pas/workspace/proc/A/status.yaml" <<'EOF'
+process: proc
+instance: A
+status: in_progress
+
+phases:
+  discovery:
+    status: pending
+EOF
+cat > "$C16DIR/.pas/workspace/proc/B/status.yaml" <<'EOF'
+process: proc
+instance: B
+status: in_progress
+
+phases:
+  discovery:
+    status: pending
+EOF
+sleep 0.05
+touch "$C16DIR/.pas/workspace/proc/B/status.yaml"  # B is mtime winner
+A_BEFORE=$(stat -c %s "$C16DIR/.pas/workspace/proc/A/status.yaml")
+B_BEFORE=$(stat -c %s "$C16DIR/.pas/workspace/proc/B/status.yaml")
+echo "{\"cwd\":\"$C16DIR\",\"source\":\"startup\",\"session_id\":\"freshid1abcdef\"}" | bash "$HOOKS_DIR/pas-session-start.sh" >/dev/null 2>&1 || true
+A_AFTER=$(stat -c %s "$C16DIR/.pas/workspace/proc/A/status.yaml")
+B_AFTER=$(stat -c %s "$C16DIR/.pas/workspace/proc/B/status.yaml")
+if [ "$A_BEFORE" = "$A_AFTER" ] && [ "$B_BEFORE" = "$B_AFTER" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-3: fresh session leaves both in_progress workspaces untouched (#173)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-3: fresh session modified status.yaml (A: $A_BEFORE→$A_AFTER, B: $B_BEFORE→$B_AFTER)")
+  printf "  ${RED}FAIL${RESET} C16-3: fresh session modified workspace (A: %s→%s, B: %s→%s)\n" "$A_BEFORE" "$A_AFTER" "$B_BEFORE" "$B_AFTER"
+fi
+rm -rf "$C16DIR"
+
+# T-C16-5a: Stop hook with binding match → gate fires normally (regression)
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/inst-bound/feedback"
+cat > "$C16DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+cat > "$C16DIR/.pas/workspace/proc/inst-bound/status.yaml" <<'EOF'
+process: proc
+instance: inst-bound
+status: in_progress
+current_session: bound123
+
+phases:
+  discovery:
+    status: completed
+EOF
+OUT=$(echo "{\"cwd\":\"$C16DIR\",\"stop_hook_active\":false,\"session_id\":\"bound123fullid\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" 2>&1 || true)
+RC=$?
+EXIT=$(echo "{\"cwd\":\"$C16DIR\",\"stop_hook_active\":false,\"session_id\":\"bound123fullid\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" >/dev/null 2>&1; echo $?)
+if [ "$EXIT" = "2" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-5a: gate fires normally when session matches binding\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-5a: expected exit 2 when bound and feedback missing, got $EXIT")
+  printf "  ${RED}FAIL${RESET} C16-5a (exit: %s)\n" "$EXIT"
+fi
+rm -rf "$C16DIR"
+
+# T-C16-5b: Stop hook with session_id NOT matching resolved workspace
+# (mtime-fallback misroute scenario) → exit 0 with stderr warning, do not block.
+C16DIR=$(mktemp -d)
+mkdir -p "$C16DIR/.pas/workspace/proc/inst-other/feedback"
+cat > "$C16DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+# Workspace is in_progress and bound to a DIFFERENT session.
+cat > "$C16DIR/.pas/workspace/proc/inst-other/status.yaml" <<'EOF'
+process: proc
+instance: inst-other
+status: in_progress
+current_session: other999
+
+phases:
+  discovery:
+    status: completed
+EOF
+OUT=$(echo "{\"cwd\":\"$C16DIR\",\"stop_hook_active\":false,\"session_id\":\"mineabc1xyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" 2>&1)
+EXIT=$(echo "{\"cwd\":\"$C16DIR\",\"stop_hook_active\":false,\"session_id\":\"mineabc1xyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" >/dev/null 2>&1; echo $?)
+if [ "$EXIT" = "0" ] && echo "$OUT" | grep -q "does not bind session mineabc1"; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C16-5b: cross-session misroute warns and skips gate (#162, #160)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C16-5b: expected exit 0 + warning, got exit $EXIT, out: $OUT")
+  printf "  ${RED}FAIL${RESET} C16-5b (exit: %s)\n" "$EXIT"
+fi
+rm -rf "$C16DIR"
 
 # =========================================================================
 # Summary

--- a/plugins/pas/hooks/verify-completion-gate.sh
+++ b/plugins/pas/hooks/verify-completion-gate.sh
@@ -24,6 +24,28 @@ fi
 guard_feedback_enabled || exit 0
 guard_active_workspace "$SCRIPT_DIR" || exit 0
 
+# Derive short session ID early so we can sanity-check the resolved workspace
+# binding (#162, #160). The full SESSION_SHORT computation happens again below
+# (kept for the fallback-from-status.yaml path); this early derivation is just
+# the input-side id, used solely to detect mtime-fallback misroutes.
+EARLY_SESSION_SHORT=""
+if [ -n "$SESSION_ID" ]; then
+  EARLY_SESSION_SHORT=$(echo "$SESSION_ID" | cut -c1-8)
+fi
+
+# Sanity check: if SESSION_ID was provided AND the resolved workspace's
+# binding field does NOT match this session id, the resolver fell through to
+# mtime fallback and we're about to demand feedback at a sibling worktree's
+# workspace. Warn and skip the gate rather than block shutdown on the wrong
+# path (#162, #160). The owning session's gate still fires when that session
+# stops; this only prevents cross-session misroutes.
+if [ -n "$EARLY_SESSION_SHORT" ] && [ -f "$ACTIVE_STATUS" ]; then
+  if ! grep -qE "^(current_session|session_id):[[:space:]]*${EARLY_SESSION_SHORT}\b" "$ACTIVE_STATUS" 2>/dev/null; then
+    echo "[PAS] Stop hook: resolved workspace ${ACTIVE_STATUS} does not bind session ${EARLY_SESSION_SHORT} — skipping completion gate (would have misrouted to a sibling workspace)" >&2
+    exit 0
+  fi
+fi
+
 # Defense-in-depth: if workspace is already completed, don't block (Issue #23)
 TOP_STATUS=$(grep '^status:' "$ACTIVE_STATUS" | head -1 | awk '{print $2}')
 if [ "$TOP_STATUS" = "completed" ]; then

--- a/plugins/pas/library/orchestration/doctrines.md
+++ b/plugins/pas/library/orchestration/doctrines.md
@@ -44,6 +44,20 @@ Cross-cycle operating rules that protect PAS from known failure modes. Each doct
 
 **How to apply:** See `discussion.md` → Data Verification Norm for the operational checklist. This doctrine is the top-level rule; `discussion.md` is the enforcement recipe.
 
+## Workspace Binding Is Skill-Owned
+
+**Rule:** Skills and processes that create or claim a workspace MUST write the session binding (`current_session:` or `session_id:` plus a `sessions:` entry) into status.yaml at workspace-creation time. The SessionStart hook will NOT auto-bind a fresh session to an existing in-progress workspace — auto-bind under concurrent worktrees clobbers sibling workspaces' bindings and triggers Stop-gate misroutes.
+
+**Why:** Cycle-16 cluster (#173, #174, #162, #160, #156, #155). Auto-bind was the original behavior; with concurrent worktrees becoming common (1.4.0+), every new session was clobbering the most-recently-touched in-progress workspace's `current_session:`. The Stop hook then demanded feedback from sessions that never ran any phase, and the resolver's mtime fallback produced cross-worktree gate misroutes.
+
+**How to apply:**
+
+- **Skill authors:** when your skill calls `mkdir -p .pas/workspace/...`, also write `current_session:` and append the session id to the `sessions:` list. See `library/orchestration/lifecycle.md` → Session Binding Contract for the schema.
+- **Reconnect detection:** SessionStart still refreshes `current_session:` automatically when the session id is already in the `sessions:` list. No skill action required for reconnects.
+- **Mismatch gating:** when a skill orchestrates worktrees (e.g. `--worktree next` style commands), grep for `PAS_WORKSPACE_MISMATCH=` in the SessionStart output before reading any other disk state, and surface a resume/skip/abort choice. The English warning is for humans; the parseable line is the contract.
+
+**Scope boundary:** processes that don't create workspaces (e.g. read-only orchestrators that only consume status from existing workspaces) are unaffected. PAS-internal processes already write status.yaml at startup per the lifecycle.md spec — they are compliant by construction.
+
 ## Adding New Doctrines
 
 New doctrines get added here when a cross-cycle pattern becomes a rule. Each doctrine must:

--- a/plugins/pas/library/orchestration/lifecycle.md
+++ b/plugins/pas/library/orchestration/lifecycle.md
@@ -23,6 +23,35 @@ Write `.pas/workspace/{process}/{slug}/status.yaml` with all phases as `pending`
 
 **If status.yaml already exists**: this is a resumed session. Read it and resume from the last completed phase (see Resumability below). Do not re-create the workspace.
 
+### Session Binding Contract
+
+When a skill or process **creates** or **claims** a workspace, it MUST write the session binding into status.yaml itself. The SessionStart hook will NOT auto-bind a fresh session to an existing in-progress workspace (would cause cross-worktree clobbering — see issue #173).
+
+The binding consists of two writes to the workspace's status.yaml:
+
+```yaml
+current_session: {first 8 chars of session_id}
+
+sessions:
+  - id: {first 8 chars of session_id}
+    started_at: {ISO timestamp}
+    completed_at: ~
+    feedback_collected: false
+```
+
+The PAS resolver (`lib/workspace.sh::find_active_workspace_status`) accepts either `current_session:` or `session_id:` as the binding field — pick the one that fits your status.yaml schema and stay consistent.
+
+**Reconnect behavior:** if a session id is already present in the `sessions:` list, the SessionStart hook treats this as a true reconnect and refreshes `current_session:` automatically. No skill action required.
+
+**Workspace mismatch signal:** when a fresh, unbound session lands while an in-progress workspace exists, the SessionStart hook emits two parseable lines for downstream skills to gate on:
+
+```
+PAS_WORKSPACE_MISMATCH={instance-slug}
+PAS_WORKSPACE_MISMATCH_PATH={absolute-workspace-path}
+```
+
+Skills that orchestrate worktrees should grep for `PAS_WORKSPACE_MISMATCH=` in the SessionStart output and surface a resume/skip/abort choice to the user before reading any other disk state.
+
 ## Lifecycle Task Creation
 
 Create lifecycle tasks using TaskCreate immediately after workspace creation. These tasks make work visible and are enforced by the `verify-task-completion.sh` hook.


### PR DESCRIPTION
## Summary

Five surgical fixes to one substrate-level race that surfaces in three places: hooks misroute to the wrong workspace under concurrent worktree/session runs.

- **`lib/workspace.sh`** — resolver Pass 0 broadened to match `current_session:` OR `session_id:` field. Closes #155.
- **`pas-session-start.sh`** — fresh sessions no longer auto-bind; only true reconnects (id already in `sessions:` list) refresh `current_session:`. Emits parseable `PAS_WORKSPACE_MISMATCH=<slug>` + `PAS_WORKSPACE_MISMATCH_PATH=<path>` lines for downstream skill gating. Closes #173, #174, #156 (issue 2).
- **`route-feedback.sh`** — warnings.log + Tier 3 anchor to `${PAS_PROJECT_ROOT:-$CWD}` instead of bare `$CWD`. Eliminates recursive `.pas/.pas/feedback/` paths under subagent CWDs and silent "Unknown target" drops. Closes #156 (issues 1 & 3).
- **`verify-completion-gate.sh`** — early sanity check: when `SESSION_ID` is provided AND the resolver-returned workspace's binding does NOT match this session id, warn to stderr and `exit 0` instead of demanding feedback at a sibling worktree's path. Closes #162, #160.

Plus docs: `lifecycle.md` Session Binding Contract, `doctrines.md` "Workspace Binding Is Skill-Owned" doctrine, `hooks/changelog.md` 1.4.1 entry. Version bumped 1.4.0 → 1.4.1.

## Validation (static / N+1 deferred)

This PR touches hook substrate. Per the **N/N+1 Protocol** doctrine, cycle-16 ships static + harness validation only; live multi-worktree behavior validation is deferred to cycle 17 from a fresh session.

- `bash -n` syntax: PASS on all hook scripts
- Test harness: 130 → 142 passing, 0 failing (+8 new C16 tests, +4 reframed session-start tests asserting the new no-auto-bind semantics)
- All landmark grep checks confirm fixes are in the working tree at the documented file:line locations

Per-issue test coverage: see `.pas/workspace/pas-development/quick/cycle-16/validation/report.md` on `dev`.

## N+1 Live Validation Checklist (Cycle 17)

Run from a fresh Claude session in a separate worktree of this repo with the merged PR's changes loaded:

- [ ] Concurrent worktree fresh-session test — fresh session in worktree A with two in-progress workspaces; confirm neither modified, `PAS_WORKSPACE_MISMATCH=` + English warning emitted
- [ ] Reconnect refresh test — manually add session id to a workspace's `sessions:` list, confirm `current_session:` is refreshed
- [ ] Stop hook cross-session no-block — workspace bound to other session id; confirm Stop exits 0 with `does not bind session ...` stderr
- [ ] Resolver `session_id:` field test — process whose status.yaml uses `session_id:`; confirm Pass 0 hits
- [ ] Route-feedback path test — trigger warning from subagent CWD inside `.pas/workspace/<X>/`; confirm log lands at `<project-root>/.pas/feedback/warnings.log` with no recursive `.pas/.pas/`

## Test plan

- [ ] Run `bash plugins/pas/hooks/tests/test-hooks.sh` → 142/142
- [ ] Verify version: `grep version plugins/pas/.claude-plugin/plugin.json` → 1.4.1
- [ ] Verify version: `grep -c '"version": "1.4.1"' .claude-plugin/marketplace.json` → 2
- [ ] Confirm new resolver regex: `grep -n 'current_session|session_id' plugins/pas/hooks/lib/workspace.sh`
- [ ] Confirm parseable line: `grep -n 'PAS_WORKSPACE_MISMATCH' plugins/pas/hooks/pas-session-start.sh`

## Issues

Closes #173
Closes #174
Closes #162
Closes #160
Closes #156
Closes #155