### PR TITLE
Release 1.4.3 — silent skip on Stop-hook gate paths + version footer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "PAS (Process, Agent, Skill) framework for building agentic workflows",
-    "version": "1.4.2"
+    "version": "1.4.3"
   },
   "plugins": [
     {
       "name": "pas",
       "source": "./plugins/pas",
       "description": "Framework for building agentic workflows with composable processes, agents, and skills. Provides /pas command to create and manage automated pipelines.",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "author": {
         "name": "Zoran Spirkovski"
       },

--- a/plugins/pas/.claude-plugin/plugin.json
+++ b/plugins/pas/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pas",
   "description": "Process-Agent-Skill framework for building agentic workflows. Create automated pipelines with composable processes, agents, and skills that improve through feedback.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "Zoran Spirkovski"
   },

--- a/plugins/pas/hooks/changelog.md
+++ b/plugins/pas/hooks/changelog.md
@@ -1,5 +1,21 @@
 # Hooks Changelog
 
+## 2026-04-28 — Cycle 18 / 1.4.3: Quiet Stop Hook + Version Footer Diagnostic
+
+The cycle-17 fix made the gate stop *blocking* on conversational yields, but the skip itself was still announcing to stderr (`[PAS] Stop hook: ... — skipping`). In long-running maintainer-style workspaces every Claude yield triggered Stop → "Ran 3 stop hooks" header + per-hook stderr → conversation visually derailed even though the gate was technically correct. Cycle-18 makes every gate-skip path completely silent.
+
+**verify-completion-gate.sh** — silent skip on cross-session misroute (cycle-16 path) and on no-advanced-phases (cycle-17 path). Both `exit 0` with zero stderr. Demand block (real "COMPLETION GATE FAILED") unchanged in timing or content, plus a one-line `(PAS plugin X.Y.Z, install: <path>)` footer so the reader can tell which install fired the block.
+
+**check-self-eval.sh** — silent bypass when a substantive response is detected (the audit `INFO:` line is gone). Demand block ("agent shutting down without writing self-evaluation") unchanged plus the version footer.
+
+**verify-task-completion.sh** — version footer added to all four demand blocks (Self-evaluation, Finalize status, Initialize workspace, phase deliverables). No silencing changes — every demand here is a real block.
+
+**lib/guards.sh** — new helper `pas_version_footer()` reads version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` and echoes the attribution line. Safe no-op if the manifest can't be read.
+
+Test harness 148 → 151 (3 re-pointed + 3 new C18 cases). Re-pointed C05-7 (substantive bypass), C16-5b (cross-session misroute), C17-1 (no-advanced-phases): skip paths now assert empty stderr instead of message content. New: C18-1 (gate footer), C18-2 (check-self-eval footer), C18-3 (verify-task-completion footer).
+
+Closes the diagnostic gap from cycle-17: when a user reports "the gate fired in my consumer", the demand block now self-attributes which plugin install emitted it. No more dependence on `${CLAUDE_PLUGIN_ROOT}` being visible in the user's shell.
+
 ## 2026-04-28 — Cycle 17 / 1.4.2: Orchestrator-Side Session Binding
 
 Triggered by recurrence of the cycle-16 cluster: even after 1.4.1 closed the hook-side auto-bind path, the bug reappeared in a consumer transcript (`pas-misrouted-and-migration-ts` in Tangled-Roots-V1). Root cause was orchestrator-side and consumer-skill-side writes to `current_session:` / `sessions:` for fresh sessions in workspaces they were not advancing — the hook's protections were sound, but the docs and SessionStart wording still encouraged manual binding. Two surgical changes plus doctrine; harness 142 → 148 (+3 new C17 wording asserts, +3 new C17 phase-advancement gate tests).

--- a/plugins/pas/hooks/check-self-eval.sh
+++ b/plugins/pas/hooks/check-self-eval.sh
@@ -68,7 +68,10 @@ if [ -n "$LAST_MSG" ] && [ "$LAST_MSG_LEN" -gt 200 ]; then
   # Known summary boilerplates that should NOT count as substantive.
   # Match the exact strings observed in #71 / #68 / #38 reports.
   if ! echo "$LAST_MSG" | head -c 400 | grep -qiE 'self-evaluation written|self-evaluation has been written|no issues detected|written to the requested location|feedback file written|written\. (no issues|task tracking)'; then
-    echo "PAS feedback hook INFO: substantive response detected (${LAST_MSG_LEN} chars), gate bypassed for agent '${AGENT_ID}'" >&2
+    # Silent bypass (cycle-18). The agent produced a substantive response,
+    # not a self-eval boilerplate — let it stop without dragging the
+    # transcript into bookkeeping. The block path below still fires when
+    # feedback is genuinely missing.
     exit 0
   fi
 fi
@@ -87,4 +90,5 @@ If nothing went wrong, the file may contain just: "No issues detected."
 Format reference: \${CLAUDE_PLUGIN_ROOT}/library/self-evaluation/SKILL.md
 To disable feedback for this project: edit .pas/config.yaml → feedback: disabled
 EOF
+pas_version_footer >&2
 exit 2

--- a/plugins/pas/hooks/lib/guards.sh
+++ b/plugins/pas/hooks/lib/guards.sh
@@ -56,6 +56,29 @@ resolve_claude_plugin_root() {
   return 2
 }
 
+# One-line attribution footer for use inside demand/block stderr messages.
+# Echoes "(PAS plugin X.Y.Z, install: <path>)" so users (or another Claude
+# session) can tell which plugin version emitted a given block — closes the
+# diagnostic gap from cycle-17/18 where the stop hook fired but we couldn't
+# tell which install was actually loaded. Safe to call after
+# resolve_claude_plugin_root() succeeds; emits nothing if the plugin.json
+# can't be read.
+pas_version_footer() {
+  local plugin_json version
+  plugin_json="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+  if [ ! -f "$plugin_json" ]; then
+    return 0
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    version=$(jq -r '.version // empty' "$plugin_json" 2>/dev/null)
+  else
+    version=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$plugin_json" | head -1)
+  fi
+  if [ -n "$version" ]; then
+    echo "(PAS plugin ${version}, install: ${CLAUDE_PLUGIN_ROOT})"
+  fi
+}
+
 # Resolve the marketplace root by walking up from a candidate cwd until
 # .claude-plugin/marketplace.json is found. Echoes the resolved root on
 # stdout; returns non-zero if no marketplace is found.

--- a/plugins/pas/hooks/tests/test-hooks.sh
+++ b/plugins/pas/hooks/tests/test-hooks.sh
@@ -876,14 +876,24 @@ assert_stdout_contains "PAS Framework Active" \
   "C05-6: orchestrator SessionStart still injects lifecycle text"
 
 # T-C05-7: substantive last_assistant_message (>200 chars, no summary
-# keywords) → exits 0 with audit-line on stderr (#71 substantive bypass).
+# keywords) → exits 0 silently (#71 substantive bypass; cycle-18 made this
+# silent — was previously emitting an audit line).
 LONG_MSG="This is a long substantive review message that contains the actual findings the parent agent needs to receive. It deliberately avoids any of the boilerplate summary phrases that the bypass heuristic looks for, so the gate must let this through. The message is well over two hundred characters so the length check passes too."
 run_hook "check-self-eval.sh" \
   "{\"cwd\":\"$C05DIR\",\"agent_id\":\"framework-architect\",\"agent_type\":\"framework-architect\",\"last_assistant_message\":\"$LONG_MSG\"}" \
   0 "C05-7: substantive response → exit 0 (#71 bypass)"
 
-assert_stderr_contains "substantive response detected" \
-  "C05-7: stderr emits audit line so bypass is visible"
+# Cycle-18: bypass is silent. stderr must be empty (run_hook echoes
+# captured stderr to the file, adding a trailing newline even when empty;
+# compare via $() which strips trailing whitespace).
+if [ -z "$(cat /tmp/test-hook-stderr)" ]; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C05-7: bypass exits silently (cycle-18, no stderr noise on conversational yields)\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C05-7: bypass should be silent, but stderr was: $(cat /tmp/test-hook-stderr)")
+  printf "  ${RED}FAIL${RESET} C05-7: bypass emitted stderr (cycle-18 expected silent)\n"
+fi
 
 # T-C05-8: short summary boilerplate → still blocks (the bug we're fixing).
 # "Self-evaluation written. No issues detected during this review." is
@@ -1956,13 +1966,14 @@ phases:
 EOF
 OUT=$(echo "{\"cwd\":\"$C16DIR\",\"stop_hook_active\":false,\"session_id\":\"mineabc1xyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" 2>&1)
 EXIT=$(echo "{\"cwd\":\"$C16DIR\",\"stop_hook_active\":false,\"session_id\":\"mineabc1xyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" >/dev/null 2>&1; echo $?)
-if [ "$EXIT" = "0" ] && echo "$OUT" | grep -q "does not bind session mineabc1"; then
+# Cycle-18: cross-session misroute now exits silently — assert empty output.
+if [ "$EXIT" = "0" ] && [ -z "$OUT" ]; then
   PASS=$((PASS + 1))
-  printf "  ${GREEN}PASS${RESET} C16-5b: cross-session misroute warns and skips gate (#162, #160)\n"
+  printf "  ${GREEN}PASS${RESET} C16-5b: cross-session misroute silently skips gate (cycle-18 silent skip)\n"
 else
   FAIL=$((FAIL + 1))
-  ERRORS+=("C16-5b: expected exit 0 + warning, got exit $EXIT, out: $OUT")
-  printf "  ${RED}FAIL${RESET} C16-5b (exit: %s)\n" "$EXIT"
+  ERRORS+=("C16-5b: expected exit 0 + empty output, got exit $EXIT, out: $OUT")
+  printf "  ${RED}FAIL${RESET} C16-5b (exit: %s, out: %s)\n" "$EXIT" "$OUT"
 fi
 rm -rf "$C16DIR"
 
@@ -1999,13 +2010,14 @@ phases:
 EOF
 OUT=$(echo "{\"cwd\":\"$C17DIR\",\"stop_hook_active\":false,\"session_id\":\"c17abc12xyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" 2>&1)
 EXIT=$(echo "{\"cwd\":\"$C17DIR\",\"stop_hook_active\":false,\"session_id\":\"c17abc12xyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" >/dev/null 2>&1; echo $?)
-if [ "$EXIT" = "0" ] && echo "$OUT" | grep -q "no advanced phases"; then
+# Cycle-18: skip path is silent — assert empty output.
+if [ "$EXIT" = "0" ] && [ -z "$OUT" ]; then
   PASS=$((PASS + 1))
-  printf "  ${GREEN}PASS${RESET} C17-1: binding matches + all phases pending → gate skipped (cycle-17)\n"
+  printf "  ${GREEN}PASS${RESET} C17-1: binding matches + all phases pending → gate silently skipped (cycle-18)\n"
 else
   FAIL=$((FAIL + 1))
-  ERRORS+=("C17-1: expected exit 0 + 'no advanced phases' warning, got exit $EXIT, out: $OUT")
-  printf "  ${RED}FAIL${RESET} C17-1 (exit: %s)\n" "$EXIT"
+  ERRORS+=("C17-1: expected exit 0 + empty output, got exit $EXIT, out: $OUT")
+  printf "  ${RED}FAIL${RESET} C17-1 (exit: %s, out: %s)\n" "$EXIT" "$OUT"
 fi
 rm -rf "$C17DIR"
 
@@ -2070,6 +2082,107 @@ else
   printf "  ${RED}FAIL${RESET} C17-3 (exit: %s)\n" "$EXIT"
 fi
 rm -rf "$C17DIR"
+
+# =========================================================================
+# Section C18: silent skips + version footer on demand blocks
+# =========================================================================
+# Cycle-18: gate-skip paths must produce zero stderr (no "Ran 3 stop hooks"
+# expansion in the transcript on conversational yields). Demand blocks must
+# include a version footer so a reader can tell which install fired the
+# block.
+
+printf "\n${BOLD}15. C18 — silent skips & version footer${RESET}\n"
+
+# T-C18-1: gate demand block includes "(PAS plugin <ver>" footer.
+C18DIR=$(mktemp -d)
+mkdir -p "$C18DIR/.pas/workspace/proc/inst/feedback"
+cat > "$C18DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+cat > "$C18DIR/.pas/workspace/proc/inst/status.yaml" <<'EOF'
+process: proc
+instance: inst
+status: in_progress
+current_session: c18abcde
+
+phases:
+  discovery:
+    status: completed
+EOF
+OUT=$(echo "{\"cwd\":\"$C18DIR\",\"stop_hook_active\":false,\"session_id\":\"c18abcdexyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" 2>&1 || true)
+EXIT=$(echo "{\"cwd\":\"$C18DIR\",\"stop_hook_active\":false,\"session_id\":\"c18abcdexyz\"}" | bash "$HOOKS_DIR/verify-completion-gate.sh" >/dev/null 2>&1; echo $?)
+if [ "$EXIT" = "2" ] && echo "$OUT" | grep -q "(PAS plugin "; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C18-1: gate demand block includes version footer\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C18-1: expected exit 2 + '(PAS plugin ' footer, got exit $EXIT")
+  printf "  ${RED}FAIL${RESET} C18-1 (exit: %s)\n" "$EXIT"
+fi
+rm -rf "$C18DIR"
+
+# T-C18-2: check-self-eval demand block includes version footer.
+# Set up a workspace with feedback/ but no agent self-eval. The hook fires
+# when the agent stops without writing one.
+C18DIR=$(mktemp -d)
+mkdir -p "$C18DIR/.pas/workspace/proc/inst/feedback"
+cat > "$C18DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+cat > "$C18DIR/.pas/workspace/proc/inst/status.yaml" <<'EOF'
+process: proc
+instance: inst
+status: in_progress
+current_session: c18abcde
+
+phases:
+  discovery:
+    status: in_progress
+    agent: test-agent
+EOF
+# SubagentStop input shape: agent_id present, last_assistant_message short
+# enough to NOT trip the substantive-response bypass at L67.
+OUT=$(echo "{\"cwd\":\"$C18DIR\",\"agent_id\":\"test-agent\",\"last_assistant_message\":\"done\"}" | bash "$HOOKS_DIR/check-self-eval.sh" 2>&1 || true)
+EXIT=$(echo "{\"cwd\":\"$C18DIR\",\"agent_id\":\"test-agent\",\"last_assistant_message\":\"done\"}" | bash "$HOOKS_DIR/check-self-eval.sh" >/dev/null 2>&1; echo $?)
+if [ "$EXIT" = "2" ] && echo "$OUT" | grep -q "(PAS plugin "; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C18-2: check-self-eval demand block includes version footer\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C18-2: expected exit 2 + '(PAS plugin ' footer, got exit $EXIT, out: $OUT")
+  printf "  ${RED}FAIL${RESET} C18-2 (exit: %s)\n" "$EXIT"
+fi
+rm -rf "$C18DIR"
+
+# T-C18-3: verify-task-completion demand block (Self-evaluation task) includes
+# version footer. The hook fires when the user marks the lifecycle task
+# complete but the corresponding feedback file does not exist.
+C18DIR=$(mktemp -d)
+mkdir -p "$C18DIR/.pas/workspace/proc/inst/feedback"
+cat > "$C18DIR/.pas/config.yaml" <<'EOF'
+feedback: enabled
+EOF
+cat > "$C18DIR/.pas/workspace/proc/inst/status.yaml" <<'EOF'
+process: proc
+instance: inst
+status: in_progress
+current_session: c18abcde
+
+phases:
+  discovery:
+    status: completed
+EOF
+OUT=$(echo "{\"cwd\":\"$C18DIR\",\"task_subject\":\"[PAS] Self-evaluation\"}" | bash "$HOOKS_DIR/verify-task-completion.sh" 2>&1 || true)
+EXIT=$(echo "{\"cwd\":\"$C18DIR\",\"task_subject\":\"[PAS] Self-evaluation\"}" | bash "$HOOKS_DIR/verify-task-completion.sh" >/dev/null 2>&1; echo $?)
+if [ "$EXIT" = "2" ] && echo "$OUT" | grep -q "(PAS plugin "; then
+  PASS=$((PASS + 1))
+  printf "  ${GREEN}PASS${RESET} C18-3: verify-task-completion demand block includes version footer\n"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("C18-3: expected exit 2 + '(PAS plugin ' footer, got exit $EXIT, out: $OUT")
+  printf "  ${RED}FAIL${RESET} C18-3 (exit: %s)\n" "$EXIT"
+fi
+rm -rf "$C18DIR"
 
 # =========================================================================
 # Summary

--- a/plugins/pas/hooks/verify-completion-gate.sh
+++ b/plugins/pas/hooks/verify-completion-gate.sh
@@ -41,7 +41,10 @@ fi
 # stops; this only prevents cross-session misroutes.
 if [ -n "$EARLY_SESSION_SHORT" ] && [ -f "$ACTIVE_STATUS" ]; then
   if ! grep -qE "^(current_session|session_id):[[:space:]]*${EARLY_SESSION_SHORT}\b" "$ACTIVE_STATUS" 2>/dev/null; then
-    echo "[PAS] Stop hook: resolved workspace ${ACTIVE_STATUS} does not bind session ${EARLY_SESSION_SHORT} — skipping completion gate (would have misrouted to a sibling workspace)" >&2
+    # Silent skip (cycle-18). The cross-session misroute would have demanded
+    # feedback at a sibling workspace — exit 0 quietly instead. The owning
+    # session's gate still fires when that session stops; this only prevents
+    # cross-session misroutes (#162, #160).
     exit 0
   fi
 fi
@@ -58,7 +61,11 @@ fi
 # (cycle-16) still skip first. This check only fires when binding matches.
 if [ -f "$ACTIVE_STATUS" ]; then
   if ! grep -qE '^[[:space:]]+status:[[:space:]]*(in_progress|completed)[[:space:]]*$' "$ACTIVE_STATUS" 2>/dev/null; then
-    echo "[PAS] Stop hook: resolved workspace ${ACTIVE_STATUS} has no advanced phases — skipping completion gate (orchestrator-side binding without phase work; see doctrines.md → Phase Advancement Test)" >&2
+    # Silent skip (cycle-18). No phase advanced past `pending`; the session
+    # did no PAS work even if `current_session:` matches. Exit 0 quietly so
+    # conversational yields in long-running maintainer-style workspaces don't
+    # add stderr noise on every turn. Doctrine: Phase Advancement Test in
+    # library/orchestration/doctrines.md.
     exit 0
   fi
 fi
@@ -160,5 +167,7 @@ ABS_EXPECTED="${ABS_FEEDBACK_DIR}/${EXPECTED_FILE}"
   echo "If your cwd differs from PAS_PROJECT_ROOT (e.g. running inside a git"
   echo "worktree), write the file at the absolute path above — the hook"
   echo "always checks that exact path."
+  echo ""
+  pas_version_footer
 } >&2
 exit 2

--- a/plugins/pas/hooks/verify-task-completion.sh
+++ b/plugins/pas/hooks/verify-task-completion.sh
@@ -46,6 +46,7 @@ Cannot complete "Self-evaluation" task: ${FEEDBACK_DIR}/${EXPECTED} does not exi
 Write your self-evaluation to this file before marking the task complete.
 Use \${CLAUDE_PLUGIN_ROOT}/library/self-evaluation/SKILL.md for the format.
 EOF
+      pas_version_footer >&2
       exit 2
     fi
     ;;
@@ -62,6 +63,7 @@ Update ${ACTIVE_STATUS}:
 - Set top-level status to "completed"
 - Set completed_at to current ISO timestamp
 EOF
+      pas_version_footer >&2
       exit 2
     fi
     ;;
@@ -74,6 +76,7 @@ Cannot complete "Initialize workspace" task: workspace feedback directory does n
 Create the workspace directory structure:
   mkdir -p ${ACTIVE_WORKSPACE}/{discovery,planning,execution/changes,validation,feedback}
 EOF
+      pas_version_footer >&2
       exit 2
     fi
     ;;
@@ -123,6 +126,7 @@ Each path under the phase's output_files: list in status.yaml must exist
 on disk before this task can be marked complete. See:
   library/orchestration/lifecycle.md (phase output_files contract)
 EOF
+        pas_version_footer >&2
         exit 2
       fi
     fi


### PR DESCRIPTION
## Release 1.4.3

Promotes cycle-18 (PR #204) from dev to main.

### What's in this release

UX fix for the Stop-hook gate derailment. Cycle-17's skip paths were correct but verbose; cycle-18 makes them completely silent. Demand blocks unchanged in behavior, plus a version footer for diagnostics.

### Test plan

- [x] `bash plugins/pas/hooks/tests/test-hooks.sh` — 151 / 0 fail
- [x] Manual trace against the offending Tangled-Roots-V1 file confirms silent skip
- [ ] Cycle-19 live validation in a fresh consumer-side session